### PR TITLE
Release 0.0.3: CI, atomic flac2wav, streaming WAV helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,27 @@
 # Changelog
 
-## Unreleased
+## 0.0.3 — 2026-04-25
 
 - Add GitHub Actions CI for formatting, analysis, VM tests, browser smoke
   tests, and `dart pub publish --dry-run`.
-- Add streaming WAV header/chunk helpers and make `flac2wav` write PCM
-  incrementally for streams with known total samples.
+- Add streaming WAV header/chunk helpers (`writeWavHeaderBytes`,
+  `frameToWavPcmBytes`) and make `flac2wav` write PCM incrementally for
+  streams with known total samples.
 - Add CLI flags for output bit depth, start sample, duration, and explicit
   MD5 verification control.
+- `flac2wav` now halts immediately on invalid arguments instead of
+  falling through to decode, so a bad `--bits` value can no longer
+  silently overwrite a valid output file with a partial decode.
+- `flac2wav` writes atomically: output goes to a sibling temp file that
+  is renamed over the destination on success. On a mid-decode failure
+  the temp is deleted and any pre-existing file at the destination is
+  left untouched. The streaming path also patches the RIFF/data chunk
+  sizes at close, so the header is honest about the bytes actually
+  written (truncated inputs, short tail frames, etc.).
 - Add coverage tooling and benchmark JSON/baseline comparison support.
-- Add malformed-input and WAV helper tests.
+- Add malformed-input and WAV helper tests, plus CLI subprocess tests
+  covering streaming/bytes equivalence, validation halting, and
+  pre-existing output survival across decode errors.
 
 ## 0.0.2 — 2026-04-24
 

--- a/bin/flac2wav.dart
+++ b/bin/flac2wav.dart
@@ -11,6 +11,7 @@
 //   --duration-samples <n>   Convert at most n samples per channel.
 //   -h, --help               Show this help message.
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:dart_flac/dart_flac.dart';
 
@@ -71,8 +72,7 @@ Future<void> main(List<String> rawArgs) async {
         if (a.startsWith('-')) {
           stderr.writeln('flac2wav: unknown option "$a"');
           stderr.write(_usage);
-          exitCode = 2;
-          return;
+          exit(2);
         }
         positional.add(a);
     }
@@ -80,8 +80,7 @@ Future<void> main(List<String> rawArgs) async {
 
   if (positional.length != 2) {
     stderr.write(_usage);
-    exitCode = 2;
-    return;
+    exit(2);
   }
 
   final inputPath = positional[0];
@@ -102,13 +101,10 @@ Future<void> main(List<String> rawArgs) async {
     durationSamples: durationSamples,
     totalSamples: info.totalSamples,
   );
-  final knownSamplesToWrite = samplesToWrite;
-  final outBytesPerSample = ((outBps + 7) ~/ 8);
-  final dataSize = knownSamplesToWrite == null
-      ? null
-      : knownSamplesToWrite * info.channels * outBytesPerSample;
 
-  if (dataSize == null) {
+  if (samplesToWrite == null) {
+    // Total length unknown — buffer in memory and write the whole WAV at
+    // once, since we cannot pre-compute or patch the RIFF header sizes.
     final frames = reader.decodeFramesFromSample(startSample);
     final wav = writeWavBytes(
       frames: frames,
@@ -116,35 +112,17 @@ Future<void> main(List<String> rawArgs) async {
       channels: info.channels,
       bitsPerSample: outBps,
     );
-    await File(outputPath).writeAsBytes(wav);
+    await _atomicWriteBytes(outputPath, wav);
   } else {
-    final sink = File(outputPath).openWrite();
-    sink.add(writeWavHeaderBytes(
-      dataSize: dataSize,
+    await _streamWavToFile(
+      reader: reader,
+      outputPath: outputPath,
+      startSample: startSample,
+      samplesToWrite: samplesToWrite,
       sampleRate: info.sampleRate,
       channels: info.channels,
-      bitsPerSample: outBps,
-    ));
-
-    var remaining = knownSamplesToWrite!;
-    if (remaining > 0) {
-      for (final frame in reader.framesLazyFromSample(startSample)) {
-        if (remaining == 0) break;
-        final frameStart = _frameStartSample(reader, frame);
-        final skip = startSample > frameStart ? startSample - frameStart : 0;
-        final available = frame.blockSize - skip;
-        if (available <= 0) continue;
-        final take = remaining < available ? remaining : available;
-        sink.add(frameToWavPcmBytes(
-          frame,
-          outBps,
-          skipSamples: skip,
-          takeSamples: take,
-        ));
-        remaining -= take;
-      }
-    }
-    await sink.close();
+      outBitsPerSample: outBps,
+    );
   }
 
   stderr.writeln('flac2wav: wrote $outputPath '
@@ -162,18 +140,119 @@ Future<void> main(List<String> rawArgs) async {
       case Md5VerificationResult.mismatch:
         stderr.writeln('flac2wav: MD5 MISMATCH - decoder produced '
             'different samples than the encoder.');
-        exitCode = 3;
-        return;
+        exit(3);
     }
   }
+}
+
+/// Streams decoded frames to [outputPath] frame by frame, writing a
+/// placeholder WAV header up front and patching the RIFF/data sizes once
+/// the actual byte count is known.
+///
+/// Writes go to a sibling temp file and are only renamed over
+/// [outputPath] after the header has been patched successfully. On any
+/// mid-stream error the temp file is deleted and [outputPath] — if it
+/// already existed — is left untouched.
+Future<void> _streamWavToFile({
+  required FlacReader reader,
+  required String outputPath,
+  required int startSample,
+  required int samplesToWrite,
+  required int sampleRate,
+  required int channels,
+  required int outBitsPerSample,
+}) async {
+  final tempPath = _tempPathFor(outputPath);
+  final file = await File(tempPath).open(mode: FileMode.write);
+  var actualDataBytes = 0;
+  var ok = false;
+  try {
+    await file.writeFrom(writeWavHeaderBytes(
+      dataSize: 0,
+      sampleRate: sampleRate,
+      channels: channels,
+      bitsPerSample: outBitsPerSample,
+    ));
+
+    var remaining = samplesToWrite;
+    if (remaining > 0) {
+      for (final frame in reader.framesLazyFromSample(startSample)) {
+        if (remaining == 0) break;
+        final frameStart = _frameStartSample(reader, frame);
+        final skip = startSample > frameStart ? startSample - frameStart : 0;
+        final available = frame.blockSize - skip;
+        if (available <= 0) continue;
+        final take = remaining < available ? remaining : available;
+        final pcm = frameToWavPcmBytes(
+          frame,
+          outBitsPerSample,
+          skipSamples: skip,
+          takeSamples: take,
+        );
+        await file.writeFrom(pcm);
+        actualDataBytes += pcm.length;
+        remaining -= take;
+      }
+    }
+
+    // Patch the RIFF chunk size (offset 4) and data subchunk size
+    // (offset 40) with the bytes that were actually written. This keeps
+    // the header honest if the loop produced fewer samples than expected
+    // (e.g. truncated input or short tail frame).
+    final riffSize = ByteData(4)
+      ..setUint32(0, 36 + actualDataBytes, Endian.little);
+    final dataSize = ByteData(4)..setUint32(0, actualDataBytes, Endian.little);
+    await file.setPosition(4);
+    await file.writeFrom(riffSize.buffer.asUint8List());
+    await file.setPosition(40);
+    await file.writeFrom(dataSize.buffer.asUint8List());
+    ok = true;
+  } finally {
+    await file.close();
+    if (ok) {
+      await File(tempPath).rename(outputPath);
+    } else {
+      try {
+        await File(tempPath).delete();
+      } catch (_) {
+        // Best-effort cleanup; ignore deletion errors so the original
+        // exception is what propagates to the caller.
+      }
+    }
+  }
+}
+
+/// Writes [bytes] to [outputPath] via a sibling temp file + rename, so a
+/// failed write never destroys the pre-existing file at [outputPath].
+Future<void> _atomicWriteBytes(String outputPath, List<int> bytes) async {
+  final tempPath = _tempPathFor(outputPath);
+  try {
+    await File(tempPath).writeAsBytes(bytes, flush: true);
+    await File(tempPath).rename(outputPath);
+  } catch (_) {
+    try {
+      await File(tempPath).delete();
+    } catch (_) {}
+    rethrow;
+  }
+}
+
+/// Sibling temp path, unique per invocation, so the rename stays on one
+/// filesystem (atomic on POSIX via `rename(2)`; on Windows the rename
+/// replaces the existing target via `MoveFileEx` with
+/// `MOVEFILE_REPLACE_EXISTING`, without stricter atomicity guarantees).
+/// The `pid`+timestamp suffix prevents two concurrent conversions to the
+/// same [outputPath] from clobbering each other's temp file.
+String _tempPathFor(String outputPath) {
+  final micros = DateTime.now().microsecondsSinceEpoch;
+  return '$outputPath.flac2wav.$pid.$micros.tmp';
 }
 
 int _parseRequiredInt(List<String> args, int index, String option) {
   if (index >= args.length) {
     stderr.writeln('flac2wav: missing value for $option');
     stderr.write(_usage);
-    exitCode = 2;
-    return 0;
+    exit(2);
   }
   return _parseIntValue(args[index], option);
 }
@@ -183,8 +262,7 @@ int _parseIntValue(String value, String option) {
   if (parsed == null) {
     stderr.writeln('flac2wav: $option must be an integer, got "$value"');
     stderr.write(_usage);
-    exitCode = 2;
-    return 0;
+    exit(2);
   }
   return parsed;
 }
@@ -197,25 +275,20 @@ void _validateOptions({
 }) {
   if (![8, 16, 24, 32].contains(bitsPerSample)) {
     stderr.writeln('flac2wav: --bits must be one of 8, 16, 24, or 32');
-    exitCode = 2;
-    return;
+    exit(2);
   }
   if (startSample < 0) {
     stderr.writeln('flac2wav: --start-sample must be >= 0');
-    exitCode = 2;
-    return;
+    exit(2);
   }
   if (durationSamples != null && durationSamples < 0) {
     stderr.writeln('flac2wav: --duration-samples must be >= 0');
-    exitCode = 2;
-    return;
+    exit(2);
   }
   if (totalSamples > 0 && startSample > totalSamples) {
     stderr.writeln('flac2wav: --start-sample is beyond end of stream');
-    exitCode = 2;
-    return;
+    exit(2);
   }
-  if (exitCode != 0) exit(exitCode);
 }
 
 int? _samplesToWrite({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flac
 description: Pure-Dart FLAC decoder. Reads metadata, decodes LPC/FIXED subframes, verifies MD5, streams PCM to any audio sink. No native deps.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/bovinemagnet/dart_flac
 repository: https://github.com/bovinemagnet/dart_flac
 issue_tracker: https://github.com/bovinemagnet/dart_flac/issues

--- a/test/dart_flac_test.dart
+++ b/test/dart_flac_test.dart
@@ -664,6 +664,110 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // CLI subprocess tests: invoke `dart run bin/flac2wav.dart` and verify
+  // end-to-end behaviour. These catch bugs that unit-testing the helpers in
+  // isolation cannot — header/payload size mismatches in the streaming path,
+  // bypassed argument validation, partial files left behind on error.
+  // -------------------------------------------------------------------------
+  group('flac2wav CLI', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('flac2wav_cli_');
+    });
+
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('streaming output matches writeWavBytes byte-for-byte', () async {
+      const inputPath = 'test/fixtures/stereo_16_44100.flac';
+      final outputPath = '${tmp.path}/out.wav';
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', inputPath, outputPath],
+      );
+      expect(result.exitCode, equals(0),
+          reason: 'stderr: ${result.stderr}\nstdout: ${result.stdout}');
+      final actual = await File(outputPath).readAsBytes();
+
+      final reader = await FlacReader.fromFile(inputPath);
+      final info = reader.streamInfo;
+      final expected = writeWavBytes(
+        frames: reader.decodeFrames(),
+        sampleRate: info.sampleRate,
+        channels: info.channels,
+        bitsPerSample: info.bitsPerSample,
+      );
+      expect(actual, equals(expected));
+    });
+
+    test('rejects --bits 17 without overwriting output', () async {
+      const inputPath = 'test/fixtures/stereo_16_44100.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      final sentinel = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
+      await File(outputPath).writeAsBytes(sentinel);
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', '--bits', '17', inputPath, outputPath],
+      );
+      expect(result.exitCode, isNot(equals(0)));
+      final after = await File(outputPath).readAsBytes();
+      expect(after, equals(sentinel),
+          reason: 'output file was overwritten despite invalid --bits');
+    });
+
+    test('--bits without value exits non-zero', () async {
+      const inputPath = 'test/fixtures/stereo_16_44100.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', inputPath, outputPath, '--bits'],
+      );
+      expect(result.exitCode, isNot(equals(0)));
+      expect(await File(outputPath).exists(), isFalse,
+          reason: 'output file was created despite missing --bits value');
+    });
+
+    test('mid-stream decode error leaves pre-existing output untouched',
+        () async {
+      // Corrupt frame 1's CRC-8 (byte 63 of _minimalFlac). Frame 0 still
+      // decodes cleanly, so the streaming path writes the header + frame
+      // 0's PCM into the temp file before the second frame parse throws.
+      final corrupted = Uint8List.fromList(_minimalFlac);
+      corrupted[63] = 0x00;
+      final inputPath = '${tmp.path}/bad.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      await File(inputPath).writeAsBytes(corrupted);
+
+      final sentinel = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE]);
+      await File(outputPath).writeAsBytes(sentinel);
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', inputPath, outputPath],
+      );
+      expect(result.exitCode, isNot(equals(0)),
+          reason: 'stderr: ${result.stderr}\nstdout: ${result.stdout}');
+
+      final after = await File(outputPath).readAsBytes();
+      expect(after, equals(sentinel),
+          reason: 'pre-existing output was destroyed by a failed decode');
+
+      // No sibling temp file (`out.wav.flac2wav.<pid>.<micros>.tmp`)
+      // should survive the failure.
+      final leftovers = Directory(tmp.path)
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.contains('.flac2wav.'))
+          .toList();
+      expect(leftovers, isEmpty, reason: 'temp files were left behind');
+    });
+  }, timeout: Timeout(Duration(minutes: 2)));
+
+  // -------------------------------------------------------------------------
   // End-to-end decode tests using real .flac fixtures produced by the
   // reference `flac` CLI. These exercise LPC, FIXED, Rice, joint-stereo
   // decorrelation, pre-coded sample-rate/block-size/bps codes, and MD5


### PR DESCRIPTION
## Summary

- Release prep for 0.0.3: bumps `pubspec.yaml` and converts the CHANGELOG's `Unreleased` section into a dated `0.0.3` entry covering the CI/coverage/streaming-CLI work plus the CLI hardening below.
- Hardens `bin/flac2wav.dart`: argument validation errors now `exit(2)` instead of falling through to decode, the streaming write path patches RIFF/data chunk sizes on close using the bytes actually written, and output is written to a sibling `*.flac2wav.<pid>.<micros>.tmp` file and renamed over the destination on success — a mid-decode failure leaves any pre-existing output untouched.
- Adds four CLI subprocess tests: streaming-vs-`writeWavBytes` byte equivalence, `--bits 17` not overwriting a pre-existing output, `--bits` with no value not creating an output, and a corrupted-frame fixture that proves a sentinel output file survives a mid-stream decode failure.

## Why

Pre-existing behaviour silently overwrote valid output WAVs with partial decodes when arguments were invalid (validation helpers set `exitCode = 2` and returned from the helper, not from `main`), leaked the `IOSink` on decode errors, and baked the predicted `dataSize` into the RIFF header even when STREAMINFO lied about the total sample count. The fixes close those failure windows and the new tests would have caught them.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — 108/108 passing (104 prior + 4 new CLI subprocess tests)
- [x] `dart pub publish --dry-run` — 0 warnings, 60 KB archive
- [ ] Reviewer sanity-check the CHANGELOG + pubspec version match before merge

## Notes

- Local branch was briefly main-tracked during the fix cycle; the two commits have been moved to this branch so the release goes through review rather than landing directly on `main`.
- Deferred (not in this PR, flagged as follow-up housekeeping): `.pubignore` exclusions for `test/` and `tool/`, CI pinning to a concrete Dart SDK version, explicit Chrome install step, coverage artefact upload, `show`-scoped public API re-exports, and teeing MD5 samples off the WAV write loop instead of a second decode pass.