### PR TITLE
Housekeeping: slim pub archive, pin CI SDK, upload coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: stable
+          # Pin to a concrete SDK so a future Dart release tightening
+          # `dart format` or `dart analyze` lints cannot turn a green
+          # commit red. Bump deliberately when upgrading the floor.
+          sdk: 3.11.5
 
       - name: Install dependencies
         run: dart pub get
@@ -29,8 +32,20 @@ jobs:
       - name: Analyze
         run: dart analyze
 
-      - name: Test on VM
-        run: dart test
+      - name: Test on VM with coverage
+        run: ./tool/coverage.sh
+
+      - name: Upload coverage (LCOV)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+
+      - name: Install Chrome
+        # Explicit install so the browser smoke test does not depend on
+        # the GitHub-hosted runner image shipping Chrome by default.
+        uses: browser-actions/setup-chrome@v1
 
       - name: Test in Chrome
         run: dart test -p chrome test/web_smoke_test.dart

--- a/.pubignore
+++ b/.pubignore
@@ -18,8 +18,11 @@ doc/api/
 # Coverage reports
 coverage/
 
-# Repository maintenance scripts
-tool/create_github_issues.sh
+# Repository maintenance scripts, coverage helpers, benchmark harness
+tool/
+
+# Test sources and binary fixtures — not needed by library consumers
+test/
 
 # dotenv
 .env*


### PR DESCRIPTION
## Summary

Three tightly-scoped CI / packaging follow-ups flagged during the 0.0.3 review, none of which affect library behaviour or the public API:

- **Slim the pub archive.** Excludes `test/` (including the binary `.flac` fixtures) and `tool/` (coverage + issue-creation scripts) via `.pubignore`. Published archive shrinks from **60 KB → 38 KB** with `0 warnings`.
- **Pin CI's Dart SDK.** Replaces `sdk: stable` with `sdk: 3.11.5` so a future Dart release that tightens `dart format` or `dart analyze` lints can't turn a green commit red without a deliberate bump here.
- **Harden the browser job.** Adds an explicit `browser-actions/setup-chrome@v1` step so the `dart test -p chrome` run does not rely on the GitHub-hosted runner image continuing to ship Chrome by default.
- **Start reporting coverage in CI.** Replaces the plain `dart test` step with the existing `./tool/coverage.sh` (already runs the full VM suite with `--coverage=coverage` and produces `coverage/lcov.info`), then uploads the LCOV as a workflow artefact via `actions/upload-artifact@v4`.

## Why

From the 0.0.3 review, marked as Important / Minor follow-ups:

> - CI pins `sdk: stable` — moving target; pin a concrete minor.
> - CI doesn't install Chrome explicitly for the browser smoke test.
> - CI never actually reports/uploads coverage — the acceptance criterion is only half-met.
> - `tool/coverage.sh` and `test/fixtures/*.flac` are published to pub.dev — consider excluding `tool/` and `test/` in `.pubignore`.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — 108/108 passing (unchanged)
- [x] `dart pub publish --dry-run` — 0 warnings; archive 38 KB; `test/` and `tool/` absent from the archive listing
- [x] `./tool/coverage.sh` locally — produces `coverage/lcov.info` (~9.4 KB) without errors
- [ ] Reviewer to confirm on first CI run that the pinned SDK, the Chrome step, and the coverage artefact all appear in the Actions run summary

## Intentionally not in this PR

Left for a separate, riskier follow-up:

- `lib/dart_flac.dart` wholesale re-exports `frame.dart` / `subframe.dart` without `show` filters — tightening this is a public-API change that needs a consumer impact review.
- Teeing MD5 samples off the WAV write loop in `flac2wav` so `--verify` doesn't re-decode the whole stream — requires widening `FlacReader.verifyMd5()` (or adding a sibling method that accepts a sample sink).