### PR TITLE
Release 0.0.4: smaller pub archive, tighter CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.4 — 2026-04-25
+
+- Published archive shrunk from 60 KB to 38 KB by excluding `test/`
+  (including the binary `.flac` fixtures) and `tool/` (coverage and
+  issue-management scripts) via `.pubignore`. No library behaviour
+  change; consumers simply get a smaller download.
+- CI now pins the Dart SDK to `3.11.5`, explicitly installs Chrome for
+  the browser smoke test, and uploads `coverage/lcov.info` as a
+  workflow artefact on every run. No consumer-visible change; tightens
+  the development feedback loop.
+
 ## 0.0.3 — 2026-04-25
 
 - Add GitHub Actions CI for formatting, analysis, VM tests, browser smoke

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flac
 description: Pure-Dart FLAC decoder. Reads metadata, decodes LPC/FIXED subframes, verifies MD5, streams PCM to any audio sink. No native deps.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/bovinemagnet/dart_flac
 repository: https://github.com/bovinemagnet/dart_flac
 issue_tracker: https://github.com/bovinemagnet/dart_flac/issues


### PR DESCRIPTION
## Summary

A maintenance release bundling the housekeeping work merged in #10. No library behaviour or public API changes; consumers of `package:dart_flac` will see:

- A smaller pub.dev archive (**60 KB → 38 KB**) — `test/` (including the binary `.flac` fixtures) and `tool/` are no longer shipped.

Contributors will see:

- CI pinned to Dart SDK `3.11.5` (no more silent breakage when stable tightens lints).
- Explicit `browser-actions/setup-chrome@v1` install before the browser smoke test.
- `coverage/lcov.info` uploaded as a workflow artefact on every CI run.

## What changed in this PR

Just the release-prep bookkeeping:

- `pubspec.yaml`: `version: 0.0.3` → `0.0.4`
- `CHANGELOG.md`: new `## 0.0.4 — 2026-04-25` section at the top, describing the housekeeping items

The underlying code changes are all already on `main` from PR #10.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — 108/108 passing (unchanged since 0.0.3)
- [x] `dart pub publish --dry-run` on the bumped version — 0 warnings, 38 KB archive
- [ ] Reviewer: sanity-check that the CHANGELOG entry accurately reflects PR #10's scope before merge

## Intentionally not in this release

From the 0.0.3 review, carried over as future work:

- Narrow the `lib/dart_flac.dart` `frame.dart` / `subframe.dart` re-exports with `show` filters (breaking change risk — needs a consumer-impact pass).
- Tee MD5 samples off the `flac2wav` WAV write loop so `--verify` does not re-decode the stream (widens `FlacReader.verifyMd5()` API).

Happy to start either as a separate branch once this lands.