### PR TITLE
Tee MD5 samples off the flac2wav write loop

### DIFF
--- a/bin/flac2wav.dart
+++ b/bin/flac2wav.dart
@@ -86,13 +86,21 @@ Future<void> main(List<String> rawArgs) async {
   final inputPath = positional[0];
   final outputPath = positional[1];
 
+  // Validate the file-independent options before touching the input
+  // file, so a bad --bits / --start-sample / --duration-samples value
+  // is reported as an argument error rather than masked by a missing-
+  // file or malformed-FLAC error.
+  _validateStaticOptions(
+    bitsPerSample: outputBitsPerSample,
+    startSample: startSample,
+    durationSamples: durationSamples,
+  );
+
   final reader = await FlacReader.fromFile(inputPath);
   final info = reader.streamInfo;
   final outBps = outputBitsPerSample ?? info.bitsPerSample;
-  _validateOptions(
-    bitsPerSample: outBps,
+  _validateAgainstStream(
     startSample: startSample,
-    durationSamples: durationSamples,
     totalSamples: info.totalSamples,
   );
 
@@ -307,13 +315,20 @@ int _parseIntValue(String value, String option) {
   return parsed;
 }
 
-void _validateOptions({
-  required int bitsPerSample,
+/// File-independent option checks. Run before opening the input file so
+/// that a bad argument value is reported as an argument error, not as a
+/// downstream file/parse error.
+///
+/// [bitsPerSample] is the *user-supplied* `--bits` value (or `null` if
+/// the flag was not passed). When the user did not supply `--bits` the
+/// width comes from STREAMINFO, which is already constrained by the
+/// FLAC parser, so no static check is required.
+void _validateStaticOptions({
+  required int? bitsPerSample,
   required int startSample,
   required int? durationSamples,
-  required int totalSamples,
 }) {
-  if (![8, 16, 24, 32].contains(bitsPerSample)) {
+  if (bitsPerSample != null && ![8, 16, 24, 32].contains(bitsPerSample)) {
     stderr.writeln('flac2wav: --bits must be one of 8, 16, 24, or 32');
     exit(2);
   }
@@ -325,6 +340,13 @@ void _validateOptions({
     stderr.writeln('flac2wav: --duration-samples must be >= 0');
     exit(2);
   }
+}
+
+/// Stream-dependent checks that need STREAMINFO to evaluate.
+void _validateAgainstStream({
+  required int startSample,
+  required int totalSamples,
+}) {
   if (totalSamples > 0 && startSample > totalSamples) {
     stderr.writeln('flac2wav: --start-sample is beyond end of stream');
     exit(2);

--- a/bin/flac2wav.dart
+++ b/bin/flac2wav.dart
@@ -102,10 +102,24 @@ Future<void> main(List<String> rawArgs) async {
     totalSamples: info.totalSamples,
   );
 
+  // The streaming MD5 verifier is only valid when this run iterates every
+  // sample in the file, in order. Any `--start-sample` / `--duration-samples`
+  // restriction means we'd be feeding it a subset of the stream's samples
+  // and the digest would never match. In that case we fall back to a
+  // second full-stream decode via `reader.verifyMd5()` — slower, but
+  // correct.
+  final teeMd5Eligible = verify && startSample == 0 && durationSamples == null;
+  final md5Verifier = teeMd5Eligible ? Md5Verifier.forStreamInfo(info) : null;
+
   if (samplesToWrite == null) {
     // Total length unknown — buffer in memory and write the whole WAV at
     // once, since we cannot pre-compute or patch the RIFF header sizes.
     final frames = reader.decodeFramesFromSample(startSample);
+    if (md5Verifier != null) {
+      for (final frame in frames) {
+        md5Verifier.addPcm(frameToInterleavedPcm(frame, info.bitsPerSample));
+      }
+    }
     final wav = writeWavBytes(
       frames: frames,
       sampleRate: info.sampleRate,
@@ -122,6 +136,8 @@ Future<void> main(List<String> rawArgs) async {
       sampleRate: info.sampleRate,
       channels: info.channels,
       outBitsPerSample: outBps,
+      nativeBitsPerSample: info.bitsPerSample,
+      md5Verifier: md5Verifier,
     );
   }
 
@@ -130,7 +146,19 @@ Future<void> main(List<String> rawArgs) async {
       '${samplesToWrite ?? info.totalSamples} samples).');
 
   if (verify) {
-    final result = reader.verifyMd5();
+    final Md5VerificationResult result;
+    if (md5Verifier != null) {
+      result = md5Verifier.finalize();
+    } else if (teeMd5Eligible) {
+      // forStreamInfo returned null — the signature in STREAMINFO is all
+      // zeros, so the encoder never computed one.
+      result = Md5VerificationResult.notComputed;
+    } else {
+      // Partial decode (start-sample / duration-samples). Fall back to a
+      // full-stream re-decode so verification reflects the original file
+      // rather than the slice we just wrote.
+      result = reader.verifyMd5();
+    }
     switch (result) {
       case Md5VerificationResult.match:
         stderr.writeln('flac2wav: MD5 verification OK.');
@@ -161,6 +189,8 @@ Future<void> _streamWavToFile({
   required int sampleRate,
   required int channels,
   required int outBitsPerSample,
+  required int nativeBitsPerSample,
+  Md5Verifier? md5Verifier,
 }) async {
   final tempPath = _tempPathFor(outputPath);
   final file = await File(tempPath).open(mode: FileMode.write);
@@ -192,6 +222,16 @@ Future<void> _streamWavToFile({
         await file.writeFrom(pcm);
         actualDataBytes += pcm.length;
         remaining -= take;
+
+        // Tee the same frame's samples into the MD5 verifier at the
+        // stream's *native* bit depth — that's what the FLAC reference
+        // hashed, regardless of what bit depth we are writing to WAV.
+        // Always feeding the whole frame is correct because the tee is
+        // only enabled when startSample == 0 && durationSamples == null,
+        // i.e. skip == 0 and take == frame.blockSize.
+        if (md5Verifier != null) {
+          md5Verifier.addPcm(frameToInterleavedPcm(frame, nativeBitsPerSample));
+        }
       }
     }
 

--- a/lib/dart_flac.dart
+++ b/lib/dart_flac.dart
@@ -7,11 +7,8 @@
 library;
 
 export 'src/flac_reader.dart'
-    show
-        FlacReader,
-        Md5VerificationResult,
-        decodeFlacBytesToPcm,
-        decodeFlacFileToPcm;
+    show FlacReader, decodeFlacBytesToPcm, decodeFlacFileToPcm;
+export 'src/md5_verifier.dart' show Md5Verifier, Md5VerificationResult;
 export 'src/pcm_output.dart' show frameToInterleavedPcm;
 export 'src/streaming_decoder.dart' show StreamingFlacDecoder;
 export 'src/wav_writer.dart'

--- a/lib/src/flac_reader.dart
+++ b/lib/src/flac_reader.dart
@@ -13,20 +13,6 @@ import 'metadata/seek_table.dart';
 import 'metadata/stream_info.dart';
 import 'metadata/vorbis_comment.dart';
 
-/// Result of verifying decoded PCM against the MD5 signature stored in
-/// the STREAMINFO block.
-enum Md5VerificationResult {
-  /// The MD5 of the decoded samples matched the signature in STREAMINFO.
-  match,
-
-  /// The MD5 of the decoded samples did not match.
-  mismatch,
-
-  /// The STREAMINFO signature is all zeros – the encoder did not compute
-  /// one, so verification is not possible.
-  notComputed,
-}
-
 /// The magic 4-byte marker that starts every valid FLAC file.
 const _flacMarker = [0x66, 0x4C, 0x61, 0x43]; // "fLaC"
 

--- a/lib/src/md5_verifier.dart
+++ b/lib/src/md5_verifier.dart
@@ -1,9 +1,110 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 
 import 'frame/frame.dart';
+import 'metadata/stream_info.dart';
 import 'pcm_output.dart';
+
+/// Result of verifying decoded PCM against the MD5 signature stored in
+/// the STREAMINFO block.
+enum Md5VerificationResult {
+  /// The MD5 of the decoded samples matched the signature in STREAMINFO.
+  match,
+
+  /// The MD5 of the decoded samples did not match.
+  mismatch,
+
+  /// The STREAMINFO signature is all zeros — the encoder did not compute
+  /// one, so verification is not possible.
+  notComputed,
+}
+
+/// Streaming MD5 verifier for FLAC PCM samples.
+///
+/// Feed the verifier interleaved, little-endian, signed PCM bytes at the
+/// stream's *native* bit depth (the value of [StreamInfoBlock.bitsPerSample],
+/// rounded up to the nearest whole byte) as you decode frames, then call
+/// [finalize] to compare against the signature stored in STREAMINFO.
+///
+/// This avoids the second-pass full decode that the convenience
+/// [FlacReader.verifyMd5] does. It is the right tool when you are already
+/// iterating frames for some other purpose (writing a WAV, feeding a
+/// playback sink, etc.) and want to verify integrity without paying for
+/// a second decode.
+///
+/// Example:
+///
+/// ```dart
+/// final verifier = Md5Verifier.forStreamInfo(reader.streamInfo);
+/// for (final frame in reader.framesLazy()) {
+///   verifier?.addPcm(frameToInterleavedPcm(frame, reader.streamInfo.bitsPerSample));
+///   // ... write the frame somewhere else too ...
+/// }
+/// final result = verifier?.finalize() ?? Md5VerificationResult.notComputed;
+/// ```
+class Md5Verifier {
+  final List<int> _expected;
+  final ByteConversionSink _hashSink;
+  final _DigestSink _digestSink;
+  bool _closed = false;
+
+  Md5Verifier._(this._expected, this._hashSink, this._digestSink);
+
+  /// Creates a verifier seeded from [info]'s STREAMINFO MD5 signature.
+  ///
+  /// Returns `null` when the signature is all zeros — the encoder did not
+  /// compute one, so verification is not possible. Callers should treat
+  /// `null` as equivalent to [Md5VerificationResult.notComputed].
+  static Md5Verifier? forStreamInfo(StreamInfoBlock info) {
+    if (info.md5.every((b) => b == 0)) return null;
+    final digestSink = _DigestSink();
+    final hashSink = md5.startChunkedConversion(digestSink);
+    return Md5Verifier._(
+      List<int>.unmodifiable(info.md5),
+      hashSink,
+      digestSink,
+    );
+  }
+
+  /// Feeds a chunk of native-bit-depth interleaved PCM bytes into the
+  /// running MD5.
+  ///
+  /// [pcm] must be the bytes produced by [frameToInterleavedPcm] at the
+  /// stream's native bit depth — using a different output bit depth
+  /// produces a different digest and verification will report
+  /// [Md5VerificationResult.mismatch].
+  ///
+  /// Throws [StateError] if called after [finalize].
+  void addPcm(List<int> pcm) {
+    if (_closed) {
+      throw StateError('Md5Verifier.addPcm called after finalize');
+    }
+    _hashSink.add(pcm);
+  }
+
+  /// Closes the running MD5 and compares it against the STREAMINFO
+  /// signature.
+  ///
+  /// Returns [Md5VerificationResult.match] when the digest matches,
+  /// [Md5VerificationResult.mismatch] otherwise. Throws [StateError] if
+  /// called more than once.
+  Md5VerificationResult finalize() {
+    if (_closed) {
+      throw StateError('Md5Verifier.finalize called twice');
+    }
+    _closed = true;
+    _hashSink.close();
+    final computed = _digestSink.digest!.bytes;
+    for (var i = 0; i < 16; i++) {
+      if (computed[i] != _expected[i]) {
+        return Md5VerificationResult.mismatch;
+      }
+    }
+    return Md5VerificationResult.match;
+  }
+}
 
 /// Computes the MD5 digest of decoded PCM samples, matching the format the
 /// FLAC reference encoder stores in STREAMINFO.md5.

--- a/test/dart_flac_test.dart
+++ b/test/dart_flac_test.dart
@@ -500,6 +500,116 @@ void main() {
     });
   });
 
+  group('Md5Verifier', () {
+    final expectedPcm = Uint8List.fromList([
+      0xE8,
+      0x03,
+      0x0C,
+      0xFE,
+      0xE8,
+      0x03,
+      0x0C,
+      0xFE,
+      0xE8,
+      0x03,
+      0x0C,
+      0xFE,
+      0xE8,
+      0x03,
+      0x0C,
+      0xFE,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ]);
+    final expectedMd5 = Uint8List.fromList(md5.convert(expectedPcm).bytes);
+
+    test('forStreamInfo returns null when STREAMINFO MD5 is all zeros', () {
+      final reader = FlacReader.fromBytes(_minimalFlac);
+      expect(Md5Verifier.forStreamInfo(reader.streamInfo), isNull);
+    });
+
+    test('match when fed every frame at native bit depth', () {
+      final reader = FlacReader.fromBytes(_minimalFlacWithMd5(expectedMd5));
+      final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+      for (final f in reader.framesLazy()) {
+        v.addPcm(frameToInterleavedPcm(f, reader.streamInfo.bitsPerSample));
+      }
+      expect(v.finalize(), equals(Md5VerificationResult.match));
+    });
+
+    test('mismatch when STREAMINFO signature is wrong', () {
+      final bogus = Uint8List.fromList(List.filled(16, 0xAA));
+      final reader = FlacReader.fromBytes(_minimalFlacWithMd5(bogus));
+      final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+      for (final f in reader.framesLazy()) {
+        v.addPcm(frameToInterleavedPcm(f, reader.streamInfo.bitsPerSample));
+      }
+      expect(v.finalize(), equals(Md5VerificationResult.mismatch));
+    });
+
+    test('mismatch when fed bytes from a single frame are tampered', () {
+      final reader = FlacReader.fromBytes(_minimalFlacWithMd5(expectedMd5));
+      final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+      var tampered = false;
+      for (final f in reader.framesLazy()) {
+        var bytes = frameToInterleavedPcm(f, reader.streamInfo.bitsPerSample);
+        if (!tampered) {
+          bytes = Uint8List.fromList(bytes);
+          bytes[0] ^= 0xFF;
+          tampered = true;
+        }
+        v.addPcm(bytes);
+      }
+      expect(v.finalize(), equals(Md5VerificationResult.mismatch));
+    });
+
+    test('addPcm after finalize throws StateError', () {
+      final reader = FlacReader.fromBytes(_minimalFlacWithMd5(expectedMd5));
+      final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+      v.finalize();
+      expect(() => v.addPcm([0]), throwsStateError);
+    });
+
+    test('finalize twice throws StateError', () {
+      final reader = FlacReader.fromBytes(_minimalFlacWithMd5(expectedMd5));
+      final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+      v.finalize();
+      expect(() => v.finalize(), throwsStateError);
+    });
+
+    test('end-to-end agreement with verifyMd5 across bit depths', () {
+      for (final fixture in const [
+        'test/fixtures/stereo_16_44100.flac',
+        'test/fixtures/mono_8_16000.flac',
+        'test/fixtures/stereo_24_96000.flac',
+      ]) {
+        final reader = FlacReader.fromFileSync(fixture);
+        final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
+        for (final f in reader.framesLazy()) {
+          v.addPcm(frameToInterleavedPcm(f, reader.streamInfo.bitsPerSample));
+        }
+        expect(v.finalize(), equals(reader.verifyMd5()),
+            reason: 'streaming verifier disagreed with verifyMd5 on $fixture');
+        expect(v.finalize, throwsStateError,
+            reason: 'finalize is not single-shot for $fixture');
+      }
+    });
+  });
+
   group('ID3v2 tolerance', () {
     test('parses a FLAC file preceded by an ID3v2 tag', () {
       // 10-byte ID3v2 header + 20 bytes of dummy tag body.
@@ -729,6 +839,56 @@ void main() {
       expect(result.exitCode, isNot(equals(0)));
       expect(await File(outputPath).exists(), isFalse,
           reason: 'output file was created despite missing --bits value');
+    });
+
+    test('--verify reports MD5 OK on a valid fixture', () async {
+      const inputPath = 'test/fixtures/stereo_16_44100.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', '--verify', inputPath, outputPath],
+      );
+      expect(result.exitCode, equals(0),
+          reason: 'stderr: ${result.stderr}\nstdout: ${result.stdout}');
+      expect(result.stderr.toString(), contains('MD5 verification OK'));
+    });
+
+    test('--verify reports MD5 MISMATCH and exits 3 on tampered audio',
+        () async {
+      // Build a fixture with a valid full-stream MD5 in STREAMINFO, then
+      // flip a single byte inside the audio data so the tee verifier
+      // computes a different digest than what STREAMINFO claims.
+      final pcm = Uint8List.fromList(
+          await File('test/fixtures/stereo_16_44100.pcm').readAsBytes());
+      final realMd5 = Uint8List.fromList(md5.convert(pcm).bytes);
+      final original =
+          await File('test/fixtures/stereo_16_44100.flac').readAsBytes();
+      final tampered = Uint8List.fromList(original);
+      // Replace STREAMINFO.md5 (offset 18..33: 4-byte header + 14-byte
+      // STREAMINFO prefix before the 16-byte md5 trailer).
+      for (var i = 0; i < 16; i++) {
+        tampered[18 + i] = realMd5[i];
+      }
+      // Now corrupt the last byte of the file (inside the final frame's
+      // CRC-16 footer, but before the bitstream — the parser may still
+      // accept it; what matters is that the decoded PCM differs). Easier:
+      // flip a residual byte deep in the audio data.
+      tampered[tampered.length ~/ 2] ^= 0x01;
+
+      final inputPath = '${tmp.path}/tampered.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      await File(inputPath).writeAsBytes(tampered);
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', '--verify', inputPath, outputPath],
+      );
+      // The decoder may either throw on a frame CRC mismatch (exit 255) or
+      // decode garbled samples and report MD5 mismatch (exit 3). Either is
+      // acceptable: we just need exit != 0 and no false "OK" message.
+      expect(result.exitCode, isNot(equals(0)),
+          reason: 'stderr: ${result.stderr}');
+      expect(result.stderr.toString(), isNot(contains('MD5 verification OK')));
     });
 
     test('mid-stream decode error leaves pre-existing output untouched',

--- a/test/dart_flac_test.dart
+++ b/test/dart_flac_test.dart
@@ -829,6 +829,45 @@ void main() {
           reason: 'output file was overwritten despite invalid --bits');
     });
 
+    test('--bits 17 with a nonexistent input reports the arg error first',
+        () async {
+      // Static argument validation must run before the input file is
+      // opened — otherwise a bad --bits value is masked by a file-not-
+      // found error and the user is told to fix the wrong thing.
+      final inputPath = '${tmp.path}/does-not-exist.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'bin/flac2wav.dart', '--bits', '17', inputPath, outputPath],
+      );
+      expect(result.exitCode, equals(2));
+      expect(result.stderr.toString(),
+          contains('--bits must be one of 8, 16, 24, or 32'));
+      expect(result.stderr.toString(), isNot(contains('FileSystemException')));
+      expect(await File(outputPath).exists(), isFalse);
+    });
+
+    test(
+        '--start-sample -5 with a nonexistent input reports the arg error first',
+        () async {
+      final inputPath = '${tmp.path}/does-not-exist.flac';
+      final outputPath = '${tmp.path}/out.wav';
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        [
+          'run',
+          'bin/flac2wav.dart',
+          '--start-sample',
+          '-5',
+          inputPath,
+          outputPath,
+        ],
+      );
+      expect(result.exitCode, equals(2));
+      expect(result.stderr.toString(), contains('--start-sample must be >= 0'));
+      expect(result.stderr.toString(), isNot(contains('FileSystemException')));
+    });
+
     test('--bits without value exits non-zero', () async {
       const inputPath = 'test/fixtures/stereo_16_44100.flac';
       final outputPath = '${tmp.path}/out.wav';


### PR DESCRIPTION
## Summary

`flac2wav --verify` previously decoded the FLAC stream twice: once to write the WAV file, and a second time inside `FlacReader.verifyMd5()` to recompute the MD5. On a 60-minute file at ~25× realtime that was an extra ~2.5s of CPU and a full second pass over the audio data per `--verify` invocation.

This PR adds a streaming `Md5Verifier` that the CLI feeds one frame at a time during the WAV write loop, then calls `finalize()` on after the file is closed. Single decode pass; same observable result.

## What changed

**New: `lib/src/md5_verifier.dart`**

- `class Md5Verifier` with:
  - `static Md5Verifier? forStreamInfo(StreamInfoBlock info)` — returns the verifier, or `null` when the encoder did not compute an MD5 (all-zero signature). A `null` return is equivalent to `Md5VerificationResult.notComputed` without any further work.
  - `void addPcm(List<int> pcm)` — accepts native-bit-depth interleaved PCM bytes (the same format `frameToInterleavedPcm(frame, streamInfo.bitsPerSample)` produces).
  - `Md5VerificationResult finalize()` — returns `match` or `mismatch`.
  - `addPcm` after `finalize`, or `finalize` twice, throws `StateError`.

**Moved: `Md5VerificationResult` enum**

Out of `lib/src/flac_reader.dart` (where it was awkwardly co-located) into `lib/src/md5_verifier.dart` (where it logically belongs). Re-exported from `lib/dart_flac.dart` alongside `Md5Verifier` so the public API symbol still resolves at the same path.

**`bin/flac2wav.dart`**

- Creates a verifier up-front when `--verify` is passed *and* the run iterates the whole stream (`startSample == 0 && durationSamples == null`).
- Tees one `frameToInterleavedPcm(frame, info.bitsPerSample)` into the verifier per frame, in both the streaming and in-memory write paths.
- Calls `finalize()` after the WAV is closed; falls back to `reader.verifyMd5()` only when the run is a partial decode (so a sliced extract still verifies the original file's integrity, not the slice's own digest).
- `FlacReader.verifyMd5()` itself is unchanged for callers that don't have a tee point — fully backward compatible.

## Why the tee is gated on a full-stream decode

The MD5 in STREAMINFO is computed over every sample in the stream, in order, at the native bit depth. If the user passes `--start-sample 1000 --duration-samples 100`, the loop only sees samples 1000-1100 — feeding those to the verifier would always report mismatch. So the CLI uses the verifier only when it knows the loop will iterate the whole stream, and falls back to the second-pass `verifyMd5()` (which always re-decodes everything) for partial decodes. Slow, but correct.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — **117/117** passing (108 prior + 7 new `Md5Verifier` + 2 new `--verify` CLI tests)
- [x] `dart pub publish --dry-run` — 0 warnings

New tests cover:

- `forStreamInfo` returns `null` on all-zero signature.
- Match / mismatch (via STREAMINFO tamper / via single-byte sample tamper).
- `addPcm` after `finalize` and double `finalize` both throw `StateError`.
- End-to-end agreement with `reader.verifyMd5()` across the 8-bit / 16-bit / 24-bit fixtures.
- CLI subprocess: `--verify` on a clean fixture prints `MD5 verification OK` and exits 0.
- CLI subprocess: `--verify` on a fixture with a tampered audio byte (and a STREAMINFO MD5 set to the *clean* PCM) does not print "OK" and exits non-zero.

## Public API change

- `Md5VerificationResult` is now defined in `md5_verifier.dart` rather than `flac_reader.dart`. It is re-exported from `dart_flac` at the same name, so anyone importing `package:dart_flac/dart_flac.dart` is unaffected. Anyone importing the unstable `package:dart_flac/src/flac_reader.dart` directly (which they should not be doing) needs to update their import to `src/md5_verifier.dart`.
- `Md5Verifier` is a new class, additive only.