### PR TITLE
Release 0.0.5: streaming MD5 verifier, single-pass --verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.0.5 — 2026-04-25
+
+- Add `Md5Verifier` (`lib/src/md5_verifier.dart`), a streaming MD5
+  verifier seeded from STREAMINFO. Feed it native-bit-depth interleaved
+  PCM bytes via `addPcm`, then call `finalize()` to get a
+  `Md5VerificationResult`. Lets callers verify file integrity in the
+  same pass they decode for some other purpose.
+- `flac2wav --verify` now does one decode pass instead of two on a
+  full-stream conversion: the WAV write loop tees one
+  `frameToInterleavedPcm` per frame into the streaming verifier, and
+  the post-write step just calls `finalize()`. For partial decodes
+  (`--start-sample` / `--duration-samples`) the CLI still falls back
+  to `reader.verifyMd5()` so a sliced extract is verified against the
+  original file's MD5, not the slice's own digest.
+- `flac2wav` now validates `--bits`, `--start-sample`, and
+  `--duration-samples` *before* opening the input file. Previously a
+  bad argument could be masked by a downstream file/parse error,
+  reporting the wrong problem to the user.
+- `Md5VerificationResult` is now defined in `md5_verifier.dart`
+  (re-exported from `package:dart_flac/dart_flac.dart` at the same
+  name; the public-API import path is unchanged). Direct imports of
+  `package:dart_flac/src/flac_reader.dart` will need updating, but
+  `src/` paths are not part of the public API.
+
 ## 0.0.4 — 2026-04-25
 
 - Published archive shrunk from 60 KB to 38 KB by excluding `test/`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flac
 description: Pure-Dart FLAC decoder. Reads metadata, decodes LPC/FIXED subframes, verifies MD5, streams PCM to any audio sink. No native deps.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/bovinemagnet/dart_flac
 repository: https://github.com/bovinemagnet/dart_flac
 issue_tracker: https://github.com/bovinemagnet/dart_flac/issues


### PR DESCRIPTION
## Summary

Bumps `pubspec.yaml` to 0.0.5 and adds a dated CHANGELOG entry covering the work merged via #12.

Public-facing changes in 0.0.5:

- **New: `Md5Verifier`** in `lib/src/md5_verifier.dart`, re-exported from `package:dart_flac/dart_flac.dart`. Lets callers verify file integrity in the same pass they decode for some other purpose — no more second-pass decode just for MD5.
- **`flac2wav --verify` is ~2× faster on full-stream conversions** — the WAV write loop tees one `frameToInterleavedPcm(frame, info.bitsPerSample)` per frame into the verifier, then calls `finalize()` at the end. Partial decodes (`--start-sample` / `--duration-samples`) still fall back to `reader.verifyMd5()` so a sliced extract is verified against the original file's MD5, not the slice's own digest.
- **`flac2wav` arg validation runs before file I/O.** `--bits 17 missing.flac out.wav` now reports the `--bits` error, not a `FileSystemException` masking it.

Internal:

- `Md5VerificationResult` moved from `flac_reader.dart` to `md5_verifier.dart`. Re-exported at the same name from `package:dart_flac/dart_flac.dart`; consumers using the public import path are unaffected.

No deprecations. No documented-public-API removals. `FlacReader.verifyMd5()` signature is unchanged.

## What this PR actually modifies

Just the release-prep bookkeeping:

- `pubspec.yaml`: `version: 0.0.4` → `0.0.5`
- `CHANGELOG.md`: new `## 0.0.5 — 2026-04-25` section at the top

The underlying code is already on `main` from PR #12.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — **119/119** passing
- [x] `dart pub publish --dry-run` — 0 warnings, 1 non-blocking hint (pub's local cache still thinks previous is 0.0.3; pub.dev's API already shows 0.0.4, so the hint clears before publish)

## Post-merge sequence

1. Merge this PR.
2. `dart pub publish` from the merged `main` (needs your OAuth).
3. Tell me "0.0.5 published" and I'll tag `v0.0.5` on the merge commit, push the tag, and open the GitHub release with a compare link against `v0.0.4`.