### PR TITLE
Narrow lib/dart_flac.dart frame re-exports (potentially breaking)

### DIFF
--- a/lib/dart_flac.dart
+++ b/lib/dart_flac.dart
@@ -21,5 +21,8 @@ export 'src/metadata/seek_table.dart';
 export 'src/metadata/vorbis_comment.dart';
 export 'src/metadata/cue_sheet.dart';
 export 'src/metadata/picture.dart';
-export 'src/frame/frame.dart';
-export 'src/frame/subframe.dart';
+// Frame types: deliberately narrow. `FrameParser` and the subframe-level
+// helpers stay package-private so the public API doesn't accidentally
+// commit to bit-stream parser internals.
+export 'src/frame/frame.dart'
+    show BlockingStrategy, ChannelAssignment, FlacFrame, FrameHeader;


### PR DESCRIPTION
## Summary

Closes the last item from the 0.0.3 review's deferred list: the wholesale re-exports of `src/frame/frame.dart` and `src/frame/subframe.dart` in `lib/dart_flac.dart` leak every public-by-default symbol in those files into `package:dart_flac/dart_flac.dart`, contradicting CLAUDE.md's "the public API surface is deliberately thin" claim.

This PR replaces those two lines with a `show`-filtered export covering only the symbols that genuinely belong in the public API.

## What stays in the public API

From `src/frame/frame.dart`:

- `FlacFrame` — the decoded frame returned by `FlacReader.framesLazy()` / `decodeFrames()`. Consumer-facing.
- `FrameHeader` — `FlacFrame.header` (sample rate, bit depth, block size, channel assignment, blocking strategy, etc.).
- `BlockingStrategy` — enum referenced by `FrameHeader.blockingStrategy`.
- `ChannelAssignment` — const-int holder referenced by `FrameHeader.channelAssignment`.

## What is no longer in the public API

- **`FrameParser`** (from `frame.dart`) — bit-stream frame parser. Takes a private `BitReader` in its API surface, so it could never be a clean public type without redesign. Not used outside the package.
- **`SubframeType`** (from `subframe.dart`) — const-int holder for FLAC subframe type codes (`constant=0`, `verbatim=1`, `fixedBase=8`, `lpcBase=32`). Internal helper, never referenced outside the package's own decode path.
- **`SubframeDecoder`** (from `subframe.dart`) — the residual / LPC / FIXED decoder. Only called from `FrameParser`. Not part of any documented usage path.

## Why now

- 0.0.3 review explicitly flagged this as Minor; it was deferred across three release cycles.
- Library is pre-1.0 — semver still allows narrowing the public surface without a major bump. After 1.0 this becomes a major-version migration.
- Doing it before any of these symbols accumulate documented external usage is the cheapest possible time.

## Breaking change risk

**Technically yes**, materially probably no:

- None of the removed symbols are documented in the README, the public API doc comments, or the example/benchmark code.
- The in-tree `*_test.dart`, `bin/flac2wav.dart`, `example/`, and `benchmark/` builds are unaffected — only the four kept symbols are referenced externally.
- An external consumer who imported `FrameParser`, `SubframeType`, or `SubframeDecoder` from `package:dart_flac/dart_flac.dart` directly will see an unresolved-symbol error on upgrade. They can either (a) drop the dependency on the internal type, or (b) file an issue and we'd consider a designed public exposure rather than an accidental wholesale export.

## Test plan

- [x] `dart analyze` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test` — **119/119** passing on the narrowed surface (existing tests reference all four kept types via the public import path; if any of `FlacFrame`/`FrameHeader`/`BlockingStrategy`/`ChannelAssignment` accidentally got removed, those tests would have failed to compile)

Diff is one file, +5/-2 lines.

## Suggested CHANGELOG entry (for the next release)

```
**Breaking**: Narrowed `package:dart_flac/dart_flac.dart` re-exports of
internal frame/subframe types. The public API still exposes `FlacFrame`,
`FrameHeader`, `BlockingStrategy`, and `ChannelAssignment`; `FrameParser`,
`SubframeType`, and `SubframeDecoder` (none of which were documented as
public) are no longer surfaced. Consumers who imported any of those three
removed symbols need to either drop the dependency or file an issue for
a designed public alternative.
```

If you'd rather wait and bundle this with a future user-visible change in 0.0.6, that's also fine — happy to either land it solo or hold the merge until there's more in the same release cycle.