### PR TITLE
Release 0.0.6: narrow public frame API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.0.6 — 2026-05-17
+
+- Narrow the public API. `package:dart_flac/dart_flac.dart` previously
+  did wholesale `export 'src/frame/frame.dart'` and
+  `export 'src/frame/subframe.dart'`, which leaked every
+  public-by-default symbol in those files into the package surface.
+  The frame export is now `show`-filtered to exactly the four types
+  that have a documented place in the public API: `BlockingStrategy`,
+  `ChannelAssignment`, `FlacFrame`, and `FrameHeader`. The
+  `subframe.dart` re-export is dropped entirely.
+- As a result, `FrameParser` (the bit-stream parser, which takes a
+  non-public `BitReader`), `SubframeType`, and `SubframeDecoder` are no
+  longer re-exported from `package:dart_flac/dart_flac.dart`. These
+  were never documented as public API — they are internal helpers used
+  only by the decoder itself. This is breaking only for code that
+  imported those symbols by accident; the package is pre-1.0, so this
+  is the right time to tighten the surface to the "deliberately thin
+  API" goal.
+
 ## 0.0.5 — 2026-04-25
 
 - Add `Md5Verifier` (`lib/src/md5_verifier.dart`), a streaming MD5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flac
 description: Pure-Dart FLAC decoder. Reads metadata, decodes LPC/FIXED subframes, verifies MD5, streams PCM to any audio sink. No native deps.
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/bovinemagnet/dart_flac
 repository: https://github.com/bovinemagnet/dart_flac
 issue_tracker: https://github.com/bovinemagnet/dart_flac/issues


### PR DESCRIPTION
## Summary

Ships release **0.0.6**, carrying the staged `narrow-frame-exports` work.

`package:dart_flac/dart_flac.dart` previously did wholesale
`export 'src/frame/frame.dart'` and `export 'src/frame/subframe.dart'`, leaking
every public-by-default symbol in those files into the package surface. This PR
narrows the frame export to a `show`-filtered list of exactly the four types with
a documented place in the public API, and drops the `subframe.dart` re-export.

**Still public:** `BlockingStrategy`, `ChannelAssignment`, `FlacFrame`, `FrameHeader`

**No longer re-exported:** `FrameParser`, `SubframeType`, `SubframeDecoder` — never
documented as public API; internal decoder helpers only. Breaking only for code
that imported those symbols by accident. Pre-1.0, so this is the right window.

## Changes

- `lib/dart_flac.dart` — `show`-filtered frame export (commit `b1d94a1`).
- `pubspec.yaml` — version `0.0.5` → `0.0.6`.
- `CHANGELOG.md` — new `0.0.6` entry.

## Verification

- `dart format --output=none --set-exit-if-changed .` — clean
- `dart analyze` — No issues found
- `dart test` — 119/119 passed
- `dart pub publish --dry-run` — 0 warnings

No in-tree consumer (`bin/`, `example/`, `benchmark/`, `test/`) imported the removed
symbols, so there are no internal regressions.