### PR TITLE
Fix 32-bit decoding, 0-bit escape partitions, and truncation recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+- Fix 32-bit stream decoding. `BitReader.readSignedBits` never
+  sign-extended 32-bit reads, and the side channel of a stereo-decorrelated
+  32-bit frame is coded at 33 bits — one wider than the reader allowed and
+  the `Int32List` sample buffer could hold. Negative 32-bit samples now
+  decode correctly, and left/side, right/side, and mid/side 32-bit frames
+  reconstruct without truncating the side channel. Subframe sample buffers
+  fall back to a plain `List<int>` only for the 33-bit side-channel case;
+  all other widths keep the `Int32List` fast path, and the public
+  `FlacFrame.channelSamples` type is unchanged.
+- Fix a crash on escaped residual partitions that declare a 0-bit sample
+  size. RFC 9639 permits such partitions (every residual in the partition
+  is 0); the decoder now produces the zeros instead of throwing.
+- `decodeFrames(recoverFromCorruption: true)` now recovers from truncated
+  frames as documented. The tolerant parser previously caught only
+  `FormatException`, but the bit reader signals end-of-data with a
+  `StateError`, so a truncated file aborted the whole decode. Both are now
+  caught, reported through `onCorruption`, and decoding resumes at the
+  next frame sync code.
+
 ## 0.0.6 — 2026-05-17
 
 - Narrow the public API. `package:dart_flac/dart_flac.dart` previously

--- a/lib/src/bit_reader.dart
+++ b/lib/src/bit_reader.dart
@@ -30,9 +30,12 @@ class BitReader {
   /// Number of bits remaining in the buffer.
   int get bitsRemaining => (_data.length - _bytePos) * 8 - _bitPos;
 
-  /// Reads [n] bits as an unsigned integer (0 ≤ n ≤ 32).
+  /// Reads [n] bits as an unsigned integer (0 ≤ n ≤ 33).
+  ///
+  /// The 33-bit maximum accommodates the side channel of a 32-bit stream,
+  /// which is coded one bit wider than the stream's bit depth.
   int readBits(int n) {
-    assert(n >= 0 && n <= 32);
+    assert(n >= 0 && n <= 33);
     if (n == 0) return 0;
 
     var result = 0;
@@ -47,7 +50,10 @@ class BitReader {
       final take = remaining < bitsInByte ? remaining : bitsInByte;
       final shift = bitsInByte - take;
       final mask = (1 << take) - 1;
-      result = (result << take) | ((_data[_bytePos] >> shift) & mask);
+      // Accumulate with * and + rather than << and |: results beyond 32
+      // bits would be truncated by the shift on the web, where bitwise
+      // operators wrap at 32 bits.
+      result = result * (1 << take) + ((_data[_bytePos] >> shift) & mask);
       _bitPos += take;
       if (_bitPos == 8) {
         _bitPos = 0;
@@ -58,12 +64,15 @@ class BitReader {
     return result;
   }
 
-  /// Reads [n] bits as a signed integer using two's complement.
+  /// Reads [n] bits as a signed integer using two's complement (1 ≤ n ≤ 33).
   int readSignedBits(int n) {
-    assert(n > 0 && n <= 32);
+    assert(n > 0 && n <= 33);
     final val = readBits(n);
-    if (n < 32 && (val & (1 << (n - 1))) != 0) {
-      return val - (1 << n);
+    // 2^(n-1) built without a ≥32-bit shift so the arithmetic stays exact
+    // on the web, where shift operands wrap at 32 bits.
+    final signBit = n <= 31 ? (1 << (n - 1)) : (1 << 30) * (1 << (n - 31));
+    if (val >= signBit) {
+      return val - signBit * 2;
     }
     return val;
   }

--- a/lib/src/frame/frame.dart
+++ b/lib/src/frame/frame.dart
@@ -294,7 +294,7 @@ class FrameParser {
     // -----------------------------------------------------------------------
     // Subframes (one per channel)
     // -----------------------------------------------------------------------
-    final rawSamples = <Int32List>[];
+    final rawSamples = <List<int>>[];
     for (var ch = 0; ch < channelCount; ch++) {
       // Side channels in stereo-coded frames need 1 extra bit.
       final extraBit = _sideChannelExtraBit(channelAssignment, ch);
@@ -349,10 +349,17 @@ class FrameParser {
 
   /// Applies joint-stereo decorrelation and returns the reconstructed PCM
   /// channel data.
+  ///
+  /// Raw subframe buffers are `List<int>` because a side channel of a
+  /// 32-bit stream carries 33-bit samples; the decorrelated output always
+  /// fits the stream's bit depth, so it is returned as [Int32List]s.
   List<Int32List> _decorrelate(
-      int channelAssignment, List<Int32List> raw, int bitsPerSample) {
+      int channelAssignment, List<List<int>> raw, int bitsPerSample) {
     if (channelAssignment == ChannelAssignment.independent) {
-      return raw;
+      return [
+        for (final channel in raw)
+          channel is Int32List ? channel : Int32List.fromList(channel),
+      ];
     }
 
     final left = Int32List(raw[0].length);
@@ -400,9 +407,10 @@ class FrameParser {
     return frames;
   }
 
-  /// Like [parseAllFrames], but on any [FormatException] thrown by
-  /// [parseFrame] (corrupt sync, bad CRC, truncated subframe) it scans
-  /// forward for the next valid frame sync code and resumes decoding.
+  /// Like [parseAllFrames], but on any [FormatException] (corrupt sync,
+  /// bad CRC) or [StateError] (truncated frame — the bit reader ran out of
+  /// data) thrown by [parseFrame] it scans forward for the next valid
+  /// frame sync code and resumes decoding.
   ///
   /// The [onError] callback is invoked once per dropped frame with the
   /// offset at which the failure occurred and the raised error.
@@ -421,7 +429,8 @@ class FrameParser {
         final (frame, nextOffset) = parseFrame(offset);
         frames.add(frame);
         offset = nextOffset;
-      } on FormatException catch (e) {
+      } catch (e) {
+        if (e is! FormatException && e is! StateError) rethrow;
         onError(offset, e);
         final next = findNextFrameSync(offset + 1);
         if (next < 0) break;

--- a/lib/src/frame/subframe.dart
+++ b/lib/src/frame/subframe.dart
@@ -17,8 +17,11 @@ abstract final class SubframeType {
 abstract final class SubframeDecoder {
   /// Decodes [blockSize] samples from [reader] using [bitsPerSample] bits.
   ///
-  /// Returns the decoded samples as an [Int32List].
-  static Int32List decode(BitReader reader, int blockSize, int bitsPerSample) {
+  /// Returns the decoded samples. The buffer is an [Int32List] except for
+  /// widths above 32 bits (the side channel of a 32-bit stream is coded at
+  /// 33 bits), where a plain list is used because an [Int32List] would
+  /// truncate the values.
+  static List<int> decode(BitReader reader, int blockSize, int bitsPerSample) {
     // Subframe header: 1 reserved bit, 6 type bits, wasted-bits flag + count.
     reader.readBit(); // zero bit (padding)
     final typeCode = reader.readBits(6);
@@ -31,17 +34,22 @@ abstract final class SubframeDecoder {
     }
     final effectiveBits = bitsPerSample - wastedBits;
 
-    final Int32List samples;
+    // Size the buffer for the full [bitsPerSample] width: the wasted-bits
+    // shift below restores values to that width even though they are read
+    // at [effectiveBits].
+    final List<int> samples = bitsPerSample > 32
+        ? List<int>.filled(blockSize, 0)
+        : Int32List(blockSize);
     if (typeCode == 0) {
-      samples = _decodeConstant(reader, blockSize, effectiveBits);
+      _decodeConstant(reader, samples, effectiveBits);
     } else if (typeCode == 1) {
-      samples = _decodeVerbatim(reader, blockSize, effectiveBits);
+      _decodeVerbatim(reader, samples, effectiveBits);
     } else if (typeCode >= 8 && typeCode <= 12) {
       final order = typeCode - 8;
-      samples = _decodeFixed(reader, blockSize, effectiveBits, order);
+      _decodeFixed(reader, samples, effectiveBits, order);
     } else if (typeCode >= 32 && typeCode <= 63) {
       final order = typeCode - 31; // LPC order 1–32
-      samples = _decodeLpc(reader, blockSize, effectiveBits, order);
+      _decodeLpc(reader, samples, effectiveBits, order);
     } else {
       throw FormatException('Unknown subframe type: $typeCode');
     }
@@ -61,10 +69,10 @@ abstract final class SubframeDecoder {
   // -------------------------------------------------------------------------
 
   /// Every sample has the same value.
-  static Int32List _decodeConstant(
-      BitReader r, int blockSize, int bitsPerSample) {
+  static void _decodeConstant(
+      BitReader r, List<int> samples, int bitsPerSample) {
     final value = r.readSignedBits(bitsPerSample);
-    return Int32List(blockSize)..fillRange(0, blockSize, value);
+    samples.fillRange(0, samples.length, value);
   }
 
   // -------------------------------------------------------------------------
@@ -72,13 +80,11 @@ abstract final class SubframeDecoder {
   // -------------------------------------------------------------------------
 
   /// Samples are stored uncompressed.
-  static Int32List _decodeVerbatim(
-      BitReader r, int blockSize, int bitsPerSample) {
-    final samples = Int32List(blockSize);
-    for (var i = 0; i < blockSize; i++) {
+  static void _decodeVerbatim(
+      BitReader r, List<int> samples, int bitsPerSample) {
+    for (var i = 0; i < samples.length; i++) {
       samples[i] = r.readSignedBits(bitsPerSample);
     }
-    return samples;
   }
 
   // -------------------------------------------------------------------------
@@ -86,9 +92,9 @@ abstract final class SubframeDecoder {
   // -------------------------------------------------------------------------
 
   /// Fixed linear predictor with [order] warm-up samples.
-  static Int32List _decodeFixed(
-      BitReader r, int blockSize, int bitsPerSample, int order) {
-    final samples = Int32List(blockSize);
+  static void _decodeFixed(
+      BitReader r, List<int> samples, int bitsPerSample, int order) {
+    final blockSize = samples.length;
 
     // Warm-up samples (uncompressed).
     for (var i = 0; i < order; i++) {
@@ -100,13 +106,11 @@ abstract final class SubframeDecoder {
 
     // Apply fixed predictor.
     _applyFixedPredictor(samples, order, blockSize);
-
-    return samples;
   }
 
   /// Applies the fixed predictor polynomial to restore sample values.
   static void _applyFixedPredictor(
-      Int32List samples, int order, int blockSize) {
+      List<int> samples, int order, int blockSize) {
     switch (order) {
       case 0:
         // order 0: signal = residual (already correct).
@@ -139,9 +143,9 @@ abstract final class SubframeDecoder {
   // -------------------------------------------------------------------------
 
   /// FIR linear predictor with [order] coefficients.
-  static Int32List _decodeLpc(
-      BitReader r, int blockSize, int bitsPerSample, int order) {
-    final samples = Int32List(blockSize);
+  static void _decodeLpc(
+      BitReader r, List<int> samples, int bitsPerSample, int order) {
+    final blockSize = samples.length;
 
     // Warm-up samples.
     for (var i = 0; i < order; i++) {
@@ -169,8 +173,6 @@ abstract final class SubframeDecoder {
       }
       samples[i] += sum >> qlpShift;
     }
-
-    return samples;
   }
 
   // -------------------------------------------------------------------------
@@ -179,7 +181,7 @@ abstract final class SubframeDecoder {
 
   /// Decodes Rice-coded residuals into [samples] starting at index [order].
   static void _decodeResidual(
-      BitReader r, int blockSize, int order, Int32List samples) {
+      BitReader r, int blockSize, int order, List<int> samples) {
     // Coding method: 0 = Rice (4-bit param), 1 = Rice2 (5-bit param).
     final codingMethod = r.readBits(2);
     final paramBits = codingMethod == 0 ? 4 : 5;
@@ -198,10 +200,17 @@ abstract final class SubframeDecoder {
       final riceParam = r.readBits(paramBits);
 
       if (riceParam == (1 << paramBits) - 1) {
-        // Escape code: samples are stored verbatim.
+        // Escape code: samples are stored verbatim. A 0-bit sample size
+        // means the partition carries no data and every residual is 0.
         final escapeBits = r.readBits(5);
-        for (var i = 0; i < samplesInPartition; i++) {
-          samples[sampleIndex++] = r.readSignedBits(escapeBits);
+        if (escapeBits == 0) {
+          for (var i = 0; i < samplesInPartition; i++) {
+            samples[sampleIndex++] = 0;
+          }
+        } else {
+          for (var i = 0; i < samplesInPartition; i++) {
+            samples[sampleIndex++] = r.readSignedBits(escapeBits);
+          }
         }
       } else {
         for (var i = 0; i < samplesInPartition; i++) {

--- a/test/dart_flac_test.dart
+++ b/test/dart_flac_test.dart
@@ -409,6 +409,28 @@ void main() {
       final r = BitReader(Uint8List.fromList([0xC2, 0x80]));
       expect(r.readUtf8CodedNumber(), equals(128));
     });
+
+    test('readSignedBits(32) sign-extends a negative value', () {
+      final r = BitReader(Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF]));
+      expect(r.readSignedBits(32), equals(-1));
+    });
+
+    test('readSignedBits(32) leaves a positive value unchanged', () {
+      final r = BitReader(Uint8List.fromList([0x7F, 0xFF, 0xFF, 0xFF]));
+      expect(r.readSignedBits(32), equals(0x7FFFFFFF));
+    });
+
+    test('readBits supports 33-bit reads', () {
+      // Side channels of a 32-bit stream are coded at 33 bits.
+      final r = BitReader(Uint8List.fromList([0x80, 0x00, 0x00, 0x00, 0x00]));
+      expect(r.readBits(33), equals(0x100000000));
+    });
+
+    test('readSignedBits(33) sign-extends the side-channel width', () {
+      // -4000000000 in 33-bit two's complement is 0x1_1194_D800.
+      final r = BitReader(Uint8List.fromList([0x88, 0xCA, 0x6C, 0x00, 0x00]));
+      expect(r.readSignedBits(33), equals(-4000000000));
+    });
   });
 
   group('CRC utilities', () {
@@ -663,6 +685,21 @@ void main() {
       // the error callback must fire at least once.
       expect(errors, isNotEmpty);
       expect(frames.length, lessThan(2));
+    });
+
+    test('tolerant decode recovers frames from a truncated file', () {
+      final full = File('test/fixtures/stereo_16_44100.flac').readAsBytesSync();
+      // Drop the final byte so the last frame is cut mid-parse (its
+      // footer CRC-16 can no longer be read).
+      final truncated = Uint8List.sublistView(full, 0, full.length - 1);
+      final reader = FlacReader.fromBytes(truncated);
+      final errors = <Object>[];
+      final frames = reader.decodeFrames(
+        recoverFromCorruption: true,
+        onCorruption: (_, e) => errors.add(e),
+      );
+      expect(frames, isNotEmpty);
+      expect(errors, isNotEmpty);
     });
   });
 
@@ -1232,6 +1269,86 @@ void main() {
     });
   });
 
+  group('32-bit streams', () {
+    test('independent constant subframes decode negative 32-bit samples', () {
+      final bytes = _buildFlacFromStreamInfoAndFrames(
+        sampleRate: 44100,
+        channels: 2,
+        bitsPerSample: 32,
+        totalSamples: 4,
+        frames: [
+          _buildConstantStereoFrame(
+            channelAssignment: 1, // 2 independent channels
+            ch0Value: -123456789,
+            ch1Value: 0x7FFFFFFF,
+            blockSize: 4,
+            bitsPerSample: 32,
+            sampleRate: 44100,
+          ),
+        ],
+      );
+      final frame = FlacReader.fromBytes(bytes).decodeFrames().single;
+      expect(frame.channelSamples[0], everyElement(equals(-123456789)));
+      expect(frame.channelSamples[1], everyElement(equals(0x7FFFFFFF)));
+    });
+
+    test('left/side stereo reconstructs a 33-bit side channel', () {
+      const left = -2000000000;
+      const right = 2000000000;
+      const side = left - right; // -4000000000: needs 33 bits
+      final bytes = _buildFlacFromStreamInfoAndFrames(
+        sampleRate: 44100,
+        channels: 2,
+        bitsPerSample: 32,
+        totalSamples: 4,
+        frames: [
+          _buildConstantStereoFrame(
+            channelAssignment: 8, // left/side
+            ch0Value: left,
+            ch1Value: side,
+            blockSize: 4,
+            bitsPerSample: 32,
+            sampleRate: 44100,
+          ),
+        ],
+      );
+      final frame = FlacReader.fromBytes(bytes).decodeFrames().single;
+      expect(frame.channelSamples[0], everyElement(equals(left)));
+      expect(frame.channelSamples[1], everyElement(equals(right)));
+    });
+  });
+
+  group('Escaped residual partitions', () {
+    test('escape partition stores residuals verbatim', () {
+      final bytes = _buildFlacFromStreamInfoAndFrames(
+        sampleRate: 44100,
+        channels: 1,
+        bitsPerSample: 16,
+        totalSamples: 4,
+        frames: [
+          _buildFixedEscapeMonoFrame(
+              blockSize: 4, escapeBits: 5, residuals: [1, -2, 3, -4]),
+        ],
+      );
+      final frame = FlacReader.fromBytes(bytes).decodeFrames().single;
+      expect(frame.channelSamples[0], equals([1, -2, 3, -4]));
+    });
+
+    test('0-bit escape partition decodes as all-zero residuals', () {
+      // RFC 9639: an escaped partition may declare a 0-bit sample size,
+      // meaning every residual in the partition is 0.
+      final bytes = _buildFlacFromStreamInfoAndFrames(
+        sampleRate: 44100,
+        channels: 1,
+        bitsPerSample: 16,
+        totalSamples: 4,
+        frames: [_buildFixedEscapeMonoFrame(blockSize: 4, escapeBits: 0)],
+      );
+      final frame = FlacReader.fromBytes(bytes).decodeFrames().single;
+      expect(frame.channelSamples[0], everyElement(equals(0)));
+    });
+  });
+
   group('Multiple metadata blocks per type', () {
     test('picturesAll exposes every PICTURE block', () {
       // Build a stream with two PICTURE blocks back-to-back.
@@ -1720,9 +1837,8 @@ List<int> _buildConstantStereoFrame({
   bw.writeBits(0x9, 4);
   // Channel assignment.
   bw.writeBits(channelAssignment, 4);
-  // Bits per sample: 16 = 0x4.
-  assert(bitsPerSample == 16);
-  bw.writeBits(0x4, 3);
+  // Bits per sample.
+  bw.writeBits(_sampleSizeCode(bitsPerSample), 3);
   bw.writeBit(0); // reserved
   // UTF-8 frame number 0.
   bw.writeBits(0x00, 8);
@@ -1795,6 +1911,63 @@ List<int> _buildConstantMonoFrameWithWastedBits({
   bw2.writeBit(1);
   // Value at effective width = bitsPerSample - wastedBits.
   bw2.writeSignedBits(rawValue, bitsPerSample - wastedBits);
+
+  bw2.alignToByte();
+  final body = bw2.toBytes();
+  final crc16 = _crc16(body);
+  return [...body, (crc16 >> 8) & 0xFF, crc16 & 0xFF];
+}
+
+/// 3-bit frame-header sample-size code for a given bit depth.
+int _sampleSizeCode(int bitsPerSample) => switch (bitsPerSample) {
+      8 => 0x1,
+      12 => 0x2,
+      16 => 0x4,
+      20 => 0x5,
+      24 => 0x6,
+      32 => 0x7,
+      _ => throw ArgumentError.value(bitsPerSample, 'bitsPerSample'),
+    };
+
+/// Builds a mono 16-bit frame whose single FIXED order-0 subframe stores
+/// its residuals in one escaped partition of [escapeBits] bits each.
+/// An [escapeBits] of 0 means the partition carries no residual data and
+/// every residual is 0.
+List<int> _buildFixedEscapeMonoFrame({
+  required int blockSize,
+  required int escapeBits,
+  List<int> residuals = const [],
+}) {
+  final bw = _BitWriter();
+  bw.writeBits(0x3FFE, 14); // sync
+  bw.writeBit(0); // reserved
+  bw.writeBit(0); // fixed blocksize
+  bw.writeBits(0x7, 4); // 16-bit follow-up blocksize
+  bw.writeBits(0x9, 4); // 44100
+  bw.writeBits(0, 4); // independent, 1 channel
+  bw.writeBits(0x4, 3); // 16-bit
+  bw.writeBit(0); // reserved
+  bw.writeBits(0x00, 8); // UTF-8 frame number 0
+  bw.writeBits(blockSize - 1, 16);
+  bw.alignToByte();
+  final hdr = bw.toBytes();
+  final bw2 = _BitWriter()
+    ..writeAllBytes(hdr)
+    ..writeBits(_crc8(hdr), 8);
+
+  // Subframe header: FIXED order 0 (type code 8), no wasted bits.
+  bw2.writeBit(0);
+  bw2.writeBits(8, 6);
+  bw2.writeBit(0);
+  // Residual: Rice method 0, partition order 0, escape code (param 0xF),
+  // 5-bit escape sample size, then the raw residuals.
+  bw2.writeBits(0, 2);
+  bw2.writeBits(0, 4);
+  bw2.writeBits(0xF, 4);
+  bw2.writeBits(escapeBits, 5);
+  for (final v in residuals) {
+    bw2.writeSignedBits(v, escapeBits);
+  }
 
   bw2.alignToByte();
   final body = bw2.toBytes();


### PR DESCRIPTION
## Summary

Three decoder correctness bugs found during a pre-release review, fixed TDD-style — every fix has a regression test that was written first and observed failing.

## 1. 32-bit streams decoded incorrectly (or crashed)

- `BitReader.readSignedBits` only sign-extended when `n < 32`, so a 32-bit read of `0xFFFFFFFF` returned 4294967295 instead of −1.
- The side channel of a stereo-decorrelated (left/side, right/side, mid/side) 32-bit frame is coded at **33 bits** — one wider than `readBits`/`readSignedBits` allowed. In debug mode (asserts on, e.g. `dart test` or a Flutter debug build) that was an `AssertionError`; in release mode the value was read but then silently truncated by the `Int32List` sample buffer whenever the side sample exceeded the int32 range.

**Fix:** `readBits`/`readSignedBits` now support up to 33 bits with correct sign extension. The accumulation uses `*`/`+` rather than `<<`/`|` and the sign threshold avoids ≥32-bit shifts, so the arithmetic also stays exact on the web (bitwise operands wrap at 32 bits under dart2js). Subframe sample buffers fall back to a plain `List<int>` only for the >32-bit side-channel case; every other width keeps the `Int32List` fast path, and the public `FlacFrame.channelSamples` type is unchanged.

## 2. Crash on 0-bit escaped residual partitions

RFC 9639 allows an escaped partition to declare a 0-bit sample size, meaning every residual in the partition is 0. That path reached `readSignedBits(0)` and crashed (`AssertionError` in debug, `ArgumentError` in release). The decoder now emits the zeros directly.

## 3. Tolerant decode did not survive truncated files

`decodeFrames(recoverFromCorruption: true)` documents recovery from truncated data, but `parseAllFramesTolerant` only caught `FormatException` — the bit reader signals end-of-data with a `StateError`, so a file cut off mid-frame aborted the entire decode. Both are now caught, reported through `onCorruption`, and decoding resumes at the next frame sync code. Anything else still rethrows.

## Tests

Nine new tests (suite: 119 → 128, all passing; `dart analyze` clean, `dart format` applied):

- `BitReader`: 32-bit negative/positive sign extension, 33-bit unsigned and signed reads.
- `32-bit streams`: independent constant subframes with negative samples; left/side frame whose side channel needs 33 bits.
- `Escaped residual partitions`: verbatim escape residuals (previously untested) and the 0-bit escape.
- `Frame resync`: a real encoder fixture truncated mid-frame decodes tolerantly, returning the intact frames and reporting the truncation.

Test helpers gained a `_sampleSizeCode` mapping (generalising `_buildConstantStereoFrame` beyond 16-bit) and a `_buildFixedEscapeMonoFrame` builder.

The CHANGELOG gains an `Unreleased` section describing all three fixes, ready to fold into the next version bump.