### PR TITLE
Fix 36-bit coded numbers, odd-depth MD5, and streaming corrupt-frame wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@
   `StateError`, so a truncated file aborted the whole decode. Both are now
   caught, reported through `onCorruption`, and decoding resumes at the
   next frame sync code.
+- Accept 7-byte UTF-8 coded numbers in frame headers. Sample numbers in
+  variable-blocksize streams are up to 36 bits, which encode as a 7-byte
+  `0xFE` sequence; the reader previously rejected it as invalid, so
+  frames beyond sample 2³¹ (roughly 13.5 hours at 44.1 kHz) failed to
+  decode.
+- Fix MD5 verification for bit depths that are not a multiple of 8.
+  The digest was computed over playback-shifted PCM, but the FLAC
+  reference encoder hashes each sample as-is in `ceil(bps/8)`
+  little-endian bytes, so `verifyMd5` reported a false mismatch on valid
+  12- and 20-bit files. A new `frameToMd5Pcm` function provides the
+  reference packing (identical to `frameToInterleavedPcm` for
+  byte-aligned depths); `computePcmMd5`, `flac2wav --verify`, and the
+  `Md5Verifier` documentation now use it.
+- `StreamingFlacDecoder` no longer wedges on a corrupt frame. A frame
+  that failed to parse (e.g. CRC mismatch) threw synchronously out of
+  `addBytes` and left the decoder stuck re-throwing at the same offset.
+  Corrupt frames are now reported as error events on the `frames`
+  stream, and decoding resumes at the next frame sync code.
 
 ## 0.0.6 — 2026-05-17
 

--- a/bin/flac2wav.dart
+++ b/bin/flac2wav.dart
@@ -125,7 +125,7 @@ Future<void> main(List<String> rawArgs) async {
     final frames = reader.decodeFramesFromSample(startSample);
     if (md5Verifier != null) {
       for (final frame in frames) {
-        md5Verifier.addPcm(frameToInterleavedPcm(frame, info.bitsPerSample));
+        md5Verifier.addPcm(frameToMd5Pcm(frame, info.bitsPerSample));
       }
     }
     final wav = writeWavBytes(
@@ -238,7 +238,7 @@ Future<void> _streamWavToFile({
         // only enabled when startSample == 0 && durationSamples == null,
         // i.e. skip == 0 and take == frame.blockSize.
         if (md5Verifier != null) {
-          md5Verifier.addPcm(frameToInterleavedPcm(frame, nativeBitsPerSample));
+          md5Verifier.addPcm(frameToMd5Pcm(frame, nativeBitsPerSample));
         }
       }
     }

--- a/lib/dart_flac.dart
+++ b/lib/dart_flac.dart
@@ -8,7 +8,8 @@ library;
 
 export 'src/flac_reader.dart'
     show FlacReader, decodeFlacBytesToPcm, decodeFlacFileToPcm;
-export 'src/md5_verifier.dart' show Md5Verifier, Md5VerificationResult;
+export 'src/md5_verifier.dart'
+    show Md5Verifier, Md5VerificationResult, frameToMd5Pcm;
 export 'src/pcm_output.dart' show frameToInterleavedPcm;
 export 'src/streaming_decoder.dart' show StreamingFlacDecoder;
 export 'src/wav_writer.dart'

--- a/lib/src/bit_reader.dart
+++ b/lib/src/bit_reader.dart
@@ -137,8 +137,12 @@ class BitReader {
 
     int extraBytes;
     int value;
-    if ((first & 0xFE) == 0xFC) {
-      // 6-byte sequence → 36-bit number
+    if (first == 0xFE) {
+      // 7-byte sequence → 36-bit number (variable-blocksize sample numbers)
+      extraBytes = 6;
+      value = 0;
+    } else if ((first & 0xFE) == 0xFC) {
+      // 6-byte sequence → 31-bit number
       extraBytes = 5;
       value = first & 0x01;
     } else if ((first & 0xFC) == 0xF8) {
@@ -167,7 +171,9 @@ class BitReader {
         throw FormatException('Invalid UTF-8 continuation byte: '
             '0x${b.toRadixString(16)}');
       }
-      value = (value << 6) | (b & 0x3F);
+      // * and + rather than << and |: a 36-bit value would be truncated
+      // by the shift on the web, where bitwise operators wrap at 32 bits.
+      value = value * 64 + (b & 0x3F);
     }
     return value;
   }

--- a/lib/src/md5_verifier.dart
+++ b/lib/src/md5_verifier.dart
@@ -23,10 +23,10 @@ enum Md5VerificationResult {
 
 /// Streaming MD5 verifier for FLAC PCM samples.
 ///
-/// Feed the verifier interleaved, little-endian, signed PCM bytes at the
-/// stream's *native* bit depth (the value of [StreamInfoBlock.bitsPerSample],
-/// rounded up to the nearest whole byte) as you decode frames, then call
-/// [finalize] to compare against the signature stored in STREAMINFO.
+/// Feed the verifier the bytes produced by [frameToMd5Pcm] at the stream's
+/// *native* bit depth ([StreamInfoBlock.bitsPerSample]) as you decode
+/// frames, then call [finalize] to compare against the signature stored in
+/// STREAMINFO.
 ///
 /// This avoids the second-pass full decode that the convenience
 /// [FlacReader.verifyMd5] does. It is the right tool when you are already
@@ -39,7 +39,7 @@ enum Md5VerificationResult {
 /// ```dart
 /// final verifier = Md5Verifier.forStreamInfo(reader.streamInfo);
 /// for (final frame in reader.framesLazy()) {
-///   verifier?.addPcm(frameToInterleavedPcm(frame, reader.streamInfo.bitsPerSample));
+///   verifier?.addPcm(frameToMd5Pcm(frame, reader.streamInfo.bitsPerSample));
 ///   // ... write the frame somewhere else too ...
 /// }
 /// final result = verifier?.finalize() ?? Md5VerificationResult.notComputed;
@@ -71,10 +71,11 @@ class Md5Verifier {
   /// Feeds a chunk of native-bit-depth interleaved PCM bytes into the
   /// running MD5.
   ///
-  /// [pcm] must be the bytes produced by [frameToInterleavedPcm] at the
-  /// stream's native bit depth — using a different output bit depth
-  /// produces a different digest and verification will report
-  /// [Md5VerificationResult.mismatch].
+  /// [pcm] must be the bytes produced by [frameToMd5Pcm] at the stream's
+  /// native bit depth — using a different output bit depth (or the
+  /// full-scale-shifted [frameToInterleavedPcm] bytes for a stream whose
+  /// depth is not a multiple of 8) produces a different digest and
+  /// verification will report [Md5VerificationResult.mismatch].
   ///
   /// Throws [StateError] if called after [finalize].
   void addPcm(List<int> pcm) {
@@ -106,18 +107,49 @@ class Md5Verifier {
   }
 }
 
+/// Packs a decoded [frame] into the byte layout the FLAC reference encoder
+/// hashes for STREAMINFO.md5: interleaved samples, each written as-is as a
+/// little-endian signed integer in `ceil(bitsPerSample / 8)` bytes.
+///
+/// Unlike [frameToInterleavedPcm], samples whose bit depth is not a
+/// multiple of 8 are *not* shifted to full scale — a 12-bit sample
+/// occupies 2 bytes holding the raw 12-bit value. For byte-aligned depths
+/// the two functions produce identical output.
+Uint8List frameToMd5Pcm(FlacFrame frame, int bitsPerSample) {
+  final bytesPerSample = (bitsPerSample + 7) ~/ 8;
+  final mask =
+      bytesPerSample == 4 ? 0xFFFFFFFF : (1 << (bytesPerSample * 8)) - 1;
+
+  final blockSize = frame.blockSize;
+  final channels = frame.channelCount;
+  final out = Uint8List(blockSize * channels * bytesPerSample);
+
+  var o = 0;
+  final channelSamples = frame.channelSamples;
+  for (var s = 0; s < blockSize; s++) {
+    for (var c = 0; c < channels; c++) {
+      final v = channelSamples[c][s] & mask;
+      for (var b = 0; b < bytesPerSample; b++) {
+        out[o++] = (v >> (b * 8)) & 0xFF;
+      }
+    }
+  }
+  return out;
+}
+
 /// Computes the MD5 digest of decoded PCM samples, matching the format the
 /// FLAC reference encoder stores in STREAMINFO.md5.
 ///
 /// The reference implementation hashes the *unencoded* interleaved audio
 /// samples, each written as a little-endian signed integer at a byte-aligned
-/// width determined by [bitsPerSample] (rounded up to the next multiple of 8).
-/// Channels are interleaved per inter-channel sample.
+/// width determined by [bitsPerSample] (rounded up to the next multiple of
+/// 8, without shifting the sample values). Channels are interleaved per
+/// inter-channel sample.
 Uint8List computePcmMd5(Iterable<FlacFrame> frames, int bitsPerSample) {
   final digestSink = _DigestSink();
   final sink = md5.startChunkedConversion(digestSink);
   for (final frame in frames) {
-    sink.add(frameToInterleavedPcm(frame, bitsPerSample));
+    sink.add(frameToMd5Pcm(frame, bitsPerSample));
   }
   sink.close();
   return Uint8List.fromList(digestSink.digest!.bytes);

--- a/lib/src/streaming_decoder.dart
+++ b/lib/src/streaming_decoder.dart
@@ -71,6 +71,10 @@ class StreamingFlacDecoder {
   /// Appends [chunk] to the internal buffer and advances the state machine
   /// as far as the buffered bytes allow.
   ///
+  /// A corrupt audio frame (e.g. a CRC mismatch) is reported as an error
+  /// event on [frames]; decoding then resumes at the next frame sync code
+  /// rather than throwing from this method.
+  ///
   /// Throws [StateError] if [close] has already been called.
   void addBytes(Uint8List chunk) {
     if (_closed) {
@@ -246,6 +250,20 @@ class StreamingFlacDecoder {
       return true;
     } on StateError {
       // Ran off the end of the buffer – need more bytes.
+      return false;
+    } on FormatException catch (e, st) {
+      // Corrupt frame (bad CRC, malformed header). Report it on the
+      // frames stream and resume at the next plausible sync code so one
+      // bad frame does not wedge the decoder.
+      _framesCtrl.addError(e, st);
+      final next = _scanForNextSync(_pos + 1);
+      if (next >= 0) {
+        _pos = next;
+        return true;
+      }
+      // No further sync in the buffer. Keep only the final byte — it may
+      // be the first half of a sync pair split across chunks.
+      _pos = _buffer.isEmpty ? 0 : _buffer.length - 1;
       return false;
     }
   }

--- a/test/dart_flac_test.dart
+++ b/test/dart_flac_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';
@@ -410,6 +411,20 @@ void main() {
       expect(r.readUtf8CodedNumber(), equals(128));
     });
 
+    test('UTF-8 coded number: seven-byte sequence (36-bit value)', () {
+      // Sample numbers in variable-blocksize streams are up to 36 bits,
+      // which need the 7-byte 0xFE form. 2^35 = FE A0 80 80 80 80 80.
+      final r = BitReader(
+          Uint8List.fromList([0xFE, 0xA0, 0x80, 0x80, 0x80, 0x80, 0x80]));
+      expect(r.readUtf8CodedNumber(), equals(0x800000000));
+    });
+
+    test('UTF-8 coded number: maximum 36-bit value', () {
+      final r = BitReader(
+          Uint8List.fromList([0xFE, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF]));
+      expect(r.readUtf8CodedNumber(), equals(0xFFFFFFFFF));
+    });
+
     test('readSignedBits(32) sign-extends a negative value', () {
       final r = BitReader(Uint8List.fromList([0xFF, 0xFF, 0xFF, 0xFF]));
       expect(r.readSignedBits(32), equals(-1));
@@ -520,6 +535,30 @@ void main() {
       final reader = FlacReader.fromBytes(bytes);
       expect(reader.verifyMd5(), equals(Md5VerificationResult.mismatch));
     });
+
+    test('verifyMd5 uses libFLAC packing for 12-bit streams', () {
+      // The reference encoder hashes each sample as-is in ceil(bps/8)
+      // little-endian bytes: a 12-bit sample occupies 2 bytes with no
+      // left shift (unlike playback PCM, which is shifted to full scale).
+      const value = -1000;
+      final packed = <int>[
+        for (var i = 0; i < 4; i++) ...[value & 0xFF, (value >> 8) & 0xFF],
+      ];
+      final digest = md5.convert(packed).bytes;
+      final bytes = _buildFlacFromStreamInfoAndFrames(
+        sampleRate: 44100,
+        channels: 1,
+        bitsPerSample: 12,
+        totalSamples: 4,
+        md5: digest,
+        frames: [
+          _buildConstantMonoFrame(
+              value: value, blockSize: 4, bitsPerSample: 12),
+        ],
+      );
+      final reader = FlacReader.fromBytes(bytes);
+      expect(reader.verifyMd5(), equals(Md5VerificationResult.match));
+    });
   });
 
   group('Md5Verifier', () {
@@ -622,7 +661,7 @@ void main() {
         final reader = FlacReader.fromFileSync(fixture);
         final v = Md5Verifier.forStreamInfo(reader.streamInfo)!;
         for (final f in reader.framesLazy()) {
-          v.addPcm(frameToInterleavedPcm(f, reader.streamInfo.bitsPerSample));
+          v.addPcm(frameToMd5Pcm(f, reader.streamInfo.bitsPerSample));
         }
         expect(v.finalize(), equals(reader.verifyMd5()),
             reason: 'streaming verifier disagreed with verifyMd5 on $fixture');
@@ -1587,6 +1626,25 @@ void main() {
       expect(info.sampleRate, equals(44100));
       expect(frames.length, equals(2));
     });
+
+    test(
+        'reports a corrupt frame as a stream error and resumes at the '
+        'next sync', () async {
+      final corrupted = Uint8List.fromList(_minimalFlac);
+      corrupted[57] ^= 0xFF; // frame 0's footer CRC-16 → CRC mismatch
+      final decoder = StreamingFlacDecoder();
+      final frames = <FlacFrame>[];
+      final errors = <Object>[];
+      final done = Completer<void>();
+      decoder.frames
+          .listen(frames.add, onError: errors.add, onDone: done.complete);
+      decoder.addBytes(corrupted); // must not throw
+      decoder.close();
+      await done.future;
+      expect(errors, isNotEmpty);
+      // Frame 1, after the corrupt frame 0, still decodes.
+      expect(frames, hasLength(1));
+    });
   });
 
   group('pcmChunks', () {
@@ -1774,6 +1832,7 @@ Uint8List _buildFlacFromStreamInfoAndFrames({
   required int bitsPerSample,
   required int totalSamples,
   required List<List<int>> frames,
+  List<int>? md5,
 }) {
   final si = _encodeStreamInfo(
     minBlockSize: 4,
@@ -1782,6 +1841,7 @@ Uint8List _buildFlacFromStreamInfoAndFrames({
     channels: channels,
     bitsPerSample: bitsPerSample,
     totalSamples: totalSamples,
+    md5: md5,
   );
   return Uint8List.fromList([
     0x66, 0x4c, 0x61, 0x43, // fLaC
@@ -1799,6 +1859,7 @@ List<int> _encodeStreamInfo({
   required int channels,
   required int bitsPerSample,
   required int totalSamples,
+  List<int>? md5,
 }) {
   final bw = _BitWriter();
   bw.writeBits(minBlockSize, 16);
@@ -1811,7 +1872,7 @@ List<int> _encodeStreamInfo({
   bw.writeBits(totalSamples >> 32, 4);
   bw.writeBits(totalSamples & 0xFFFFFFFF, 32);
   final body = bw.toBytes();
-  return [...body, ...List.filled(16, 0)]; // MD5 all-zero
+  return [...body, ...(md5 ?? List.filled(16, 0))];
 }
 
 /// Builds a single FLAC audio frame with two CONSTANT subframes, encoded
@@ -1868,6 +1929,40 @@ List<int> _buildConstantStereoFrame({
   bw2.writeSignedBits(ch1Value, ch1Bits);
 
   // Byte-align for footer CRC-16.
+  bw2.alignToByte();
+  final body = bw2.toBytes();
+  final crc16 = _crc16(body);
+  return [...body, (crc16 >> 8) & 0xFF, crc16 & 0xFF];
+}
+
+/// Builds a single mono frame with one CONSTANT subframe.
+List<int> _buildConstantMonoFrame({
+  required int value,
+  required int blockSize,
+  required int bitsPerSample,
+}) {
+  final bw = _BitWriter();
+  bw.writeBits(0x3FFE, 14); // sync
+  bw.writeBit(0); // reserved
+  bw.writeBit(0); // fixed blocksize
+  bw.writeBits(0x7, 4); // 16-bit follow-up blocksize
+  bw.writeBits(0x9, 4); // 44100
+  bw.writeBits(0, 4); // independent, 1 channel
+  bw.writeBits(_sampleSizeCode(bitsPerSample), 3);
+  bw.writeBit(0); // reserved
+  bw.writeBits(0x00, 8); // UTF-8 frame number 0
+  bw.writeBits(blockSize - 1, 16);
+  bw.alignToByte();
+  final hdr = bw.toBytes();
+  final bw2 = _BitWriter()
+    ..writeAllBytes(hdr)
+    ..writeBits(_crc8(hdr), 8);
+
+  bw2.writeBit(0); // zero padding
+  bw2.writeBits(0, 6); // type code 0 = CONSTANT
+  bw2.writeBit(0); // no wasted bits
+  bw2.writeSignedBits(value, bitsPerSample);
+
   bw2.alignToByte();
   final body = bw2.toBytes();
   final crc16 = _crc16(body);


### PR DESCRIPTION
## Summary

The remaining three confirmed bugs from the pre-release review (items 4–6), fixed TDD-style on top of #16 — every fix has a regression test that was written first and observed failing. **Stacked on #16**: the base branch is `decoder-correctness-fixes`; GitHub will retarget this PR to `main` when #16 merges.

## 4. 36-bit UTF-8 coded numbers rejected

`readUtf8CodedNumber` had no branch for the 7-byte `0xFE` form, which carries the 36-bit sample numbers used by variable-blocksize streams — any frame whose sample number exceeds 2³¹ (~13.5 hours at 44.1 kHz) threw `FormatException`. The 6-byte branch was also mislabelled "36-bit" (it carries 31). The accumulator now uses `*`/`+` instead of `<<`/`|` so 36-bit values stay exact on the web, where bitwise operators wrap at 32 bits.

## 5. False MD5 mismatch on 12-/20-bit files

`computePcmMd5` hashed the output of `frameToInterleavedPcm`, which left-shifts samples to full scale (a 12-bit sample gets `<< 4` in its 16-bit slot). The FLAC reference encoder hashes each sample **as-is** in `ceil(bps/8)` little-endian bytes, so `verifyMd5` reported `mismatch` on valid files whose depth is not a multiple of 8.

**Fix:** new public `frameToMd5Pcm(frame, bitsPerSample)` implements the reference packing (byte-identical to `frameToInterleavedPcm` for byte-aligned depths, so existing digests for 8/16/24/32-bit streams are unchanged). `computePcmMd5`, both `flac2wav --verify` tee sites, and the `Md5Verifier` doc example now use it.

## 6. StreamingFlacDecoder wedged permanently on a corrupt frame

`_tryParseFrame` caught `StateError` (need more bytes) but not `FormatException` (CRC mismatch / malformed header). The exception escaped `addBytes` synchronously, and because `_pos` never advanced, every subsequent `addBytes` rethrew the same error. Corrupt frames are now reported as **error events on the `frames` stream** — consistent with how `close()` already routes errors — and decoding resumes at the next frame sync code. When no further sync is buffered, the decoder keeps the final byte (it may be the first half of a sync pair split across chunks) and waits for more data.

## Tests

Four new tests (suite: 128 → 132, all passing; `dart analyze` clean):

- `BitReader`: 7-byte coded number for 2³⁵ and the maximum 36-bit value.
- `MD5 verification`: a hand-built 12-bit stream whose STREAMINFO carries the reference-packed digest must verify as `match`.
- `StreamingFlacDecoder`: a corrupted frame CRC must surface as a stream error event (not a throw from `addBytes`), and the following frame must still decode.

Test helpers gained `_buildConstantMonoFrame` and an optional `md5` parameter on the STREAMINFO builders. The existing cross-depth agreement test now feeds `frameToMd5Pcm`, matching the updated documentation.

The CHANGELOG's `Unreleased` section is extended with all three fixes.