### PR TITLE
Release 0.0.7: decoder robustness, web exactness, faster Rice decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.7 — 2026-07-06
 
 - Reject malformed metadata and frame fields with `FormatException`.
   Corrupt length fields in VORBIS_COMMENT, PICTURE, and CUESHEET blocks
@@ -64,6 +64,12 @@
   `addBytes` and left the decoder stuck re-throwing at the same offset.
   Corrupt frames are now reported as error events on the `frames`
   stream, and decoding resumes at the next frame sync code.
+- Expand test coverage: VERBATIM subframes, Rice2 (5-bit parameter)
+  residual coding, and variable-blocksize frames with UTF-8 coded sample
+  numbers now have synthetic-frame tests; a fourth real fixture (seeded
+  noise, stored by the reference encoder as VERBATIM subframes) and
+  browser regression tests for the beyond-32-bit arithmetic paths back
+  them up.
 
 ## 0.0.6 — 2026-05-17
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_flac
 description: Pure-Dart FLAC decoder. Reads metadata, decodes LPC/FIXED subframes, verifies MD5, streams PCM to any audio sink. No native deps.
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/bovinemagnet/dart_flac
 repository: https://github.com/bovinemagnet/dart_flac
 issue_tracker: https://github.com/bovinemagnet/dart_flac/issues


### PR DESCRIPTION
Cuts 0.0.7. Everything below was already merged to main; this PR renames the CHANGELOG's Unreleased section to `0.0.7 — 2026-07-06` (adding an entry for the expanded test coverage) and bumps the pubspec version.

## In this release

- Three decoder correctness fixes from the pre-release review: 7-byte (36-bit) UTF-8 coded numbers, reference-packed MD5 for 12-/20-bit depths (new public `frameToMd5Pcm`), and `StreamingFlacDecoder` corrupt-frame recovery (#18).
- Malformed metadata/frame fields now raise `FormatException` instead of `RangeError`/`ArgumentError`/silent corruption (#19).
- Decoder arithmetic stays exact beyond 32 bits under dart2js (Rice zigzag, LPC accumulator, mid/side reconstruction) (#19).
- ~15% faster decoding: byte-at-a-time unary scanning and zero-copy frame CRC checks (#19).
- Narrowed metadata export (potentially breaking for accidental imports of the internal byte helpers) (#19).
- Expanded coverage: VERBATIM / Rice2 / variable-blocksize tests, a noise fixture, and browser regression tests (#19).

`dart analyze` clean, 153 VM + 6 Chrome tests passing, `dart pub publish --dry-run` clean (45 KB archive).

After merge: tag `v0.0.7` on the merge commit.